### PR TITLE
Surface detailed view toggle in browser and load OmniClass data

### DIFF
--- a/BIMaestro/BIMaestro.csproj
+++ b/BIMaestro/BIMaestro.csproj
@@ -323,6 +323,7 @@
       <DependentUpon>FamilyBrowserPlugin.xaml</DependentUpon>
     </Compile>
     <Compile Include="commands\Dossier famille\FamilyIndexService.cs" />
+    <Compile Include="commands\Dossier famille\FamilyMetadataProvider.cs" />
     <Compile Include="commands\Dossier famille\FamilyLoadOption.cs" />
     <Compile Include="commands\Dossier famille\FamilyUsageManager.cs" />
     <Compile Include="commands\Dossier famille\image native de revit\ThumbnailCache.cs" />

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -23,6 +23,14 @@
         <SolidColorBrush x:Key="TabBackground"      Color="Transparent"/>
         <SolidColorBrush x:Key="ImageBackground"    Color="Transparent"/>
 
+        <ItemsPanelTemplate x:Key="FamilyListWrapPanel">
+            <WrapPanel IsItemsHost="True"/>
+        </ItemsPanelTemplate>
+
+        <ItemsPanelTemplate x:Key="FamilyListStackPanel">
+            <StackPanel IsItemsHost="True" Orientation="Vertical"/>
+        </ItemsPanelTemplate>
+
         <!-- Styles -->
         <Style TargetType="TreeViewItem">
             <Setter Property="Foreground" Value="{DynamicResource PrimaryText}"/>
@@ -120,6 +128,144 @@
                                    HorizontalAlignment="Center"
                                    Margin="0,0,5,0"
                                    ToolTip="Nom complet de la famille"/>
+                    </Grid>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FamilyItemDetailedTemplate" DataType="{x:Type local:FamilyItem}">
+            <Border Margin="5"
+                    Background="{DynamicResource PanelBackground}"
+                    CornerRadius="5"
+                    MouseLeftButtonDown="FamilyItem_DoubleClick"
+                    HorizontalAlignment="Stretch">
+                <Border.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Rentrer dans la famille"
+                                  Click="OpenFamilyFile_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        <MenuItem Header="Charger la dernière version"
+                                  Click="ReloadFamily_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+
+                        <Separator/>
+
+                        <MenuItem Header="Ajouter à la collection active"
+                                  Click="AddToActiveCollection_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                    </ContextMenu>
+                </Border.ContextMenu>
+
+                <Grid Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="220"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Background="{DynamicResource ImageBackground}"
+                            Padding="3"
+                            Grid.Column="0"
+                            HorizontalAlignment="Left">
+                        <Image Source="{Binding Icon}"
+                               Width="200" Height="200"
+                               Stretch="Uniform"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource ImageStyle}"/>
+                    </Border>
+
+                    <Grid Grid.Column="1" Margin="15,0,5,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <DockPanel Grid.Row="0" LastChildFill="True">
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Content="3D"
+                                        Width="32" Height="22" FontSize="10" Padding="0"
+                                        Margin="0,0,8,0"
+                                        Click="OnPreview3DClick"
+                                        ToolTip="Aperçu 3D de la famille"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        BorderBrush="Transparent"
+                                        FocusVisualStyle="{x:Null}"/>
+                                <Button Content="★"
+                                        Click="FavoriteButton_Click"
+                                        ToolTip="Ajouter/retirer des Favoris"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        FontSize="18"
+                                        Width="32"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,0,0">
+                                    <Button.Style>
+                                        <Style TargetType="Button">
+                                            <Setter Property="Foreground" Value="SkyBlue"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsFavorite}" Value="True">
+                                                    <Setter Property="Foreground" Value="Orange"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </StackPanel>
+                            <TextBlock Text="{Binding Name}"
+                                       Foreground="{DynamicResource PrimaryText}"
+                                       FontWeight="Bold"
+                                       FontSize="16"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,10,0"
+                                       VerticalAlignment="Center"/>
+                        </DockPanel>
+
+                        <TextBlock Grid.Row="1"
+                                   Foreground="{DynamicResource PrimaryText}"
+                                   Margin="0,6,0,0"
+                                   TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Category}" Value="">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Category}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                            <Run Text="Catégorie : "/>
+                            <Run Text="{Binding Category}"/>
+                        </TextBlock>
+
+                        <TextBlock Grid.Row="2"
+                                   Foreground="{DynamicResource PrimaryText}"
+                                   Margin="0,6,0,0"
+                                   TextWrapping="Wrap">
+                            <Run Text="Chemin : "/>
+                            <Run Text="{Binding Path}"/>
+                        </TextBlock>
+
+                        <TextBlock Grid.Row="3"
+                                   Foreground="{DynamicResource PrimaryText}"
+                                   Margin="0,6,0,0"
+                                   TextWrapping="Wrap">
+                            <Run Text="Numéro OmniClass : "/>
+                            <Run Text="{Binding OmniClassNumber, TargetNullValue=—}"/>
+                        </TextBlock>
+
+                        <TextBlock Grid.Row="4"
+                                   Foreground="Gray"
+                                   Margin="0,6,0,0"
+                                   FontStyle="Italic"
+                                   Text="Double-cliquer pour charger la famille"/>
                     </Grid>
                 </Grid>
             </Border>
@@ -287,13 +433,8 @@
 
                                 <!-- Résultats paginés -->
                                 <ItemsControl x:Name="FamilyListView"
-                                              ItemTemplate="{StaticResource FamilyItemTemplate}">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel IsItemsHost="True"/>
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                </ItemsControl>
+                                              ItemTemplate="{StaticResource FamilyItemTemplate}"
+                                              ItemsPanel="{StaticResource FamilyListWrapPanel}"/>
 
                                 <TextBlock x:Name="PagingStatusText"
                                            Margin="8,12,8,20"
@@ -304,6 +445,14 @@
                         </ScrollViewer>
 
                         <DockPanel Grid.Row="3">
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                                <CheckBox x:Name="DetailedViewCheckBox"
+                                          Content="Vue détaillée"
+                                          Margin="0,0,20,0"
+                                          Foreground="{DynamicResource PrimaryText}"
+                                          Checked="DetailedViewCheckBox_Changed"
+                                          Unchecked="DetailedViewCheckBox_Changed"/>
+                            </StackPanel>
                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
                                 <TextBlock Text="Familles affichées : " Foreground="{DynamicResource PrimaryText}"/>
                                 <TextBlock x:Name="CountTextBlock" Foreground="{DynamicResource PrimaryText}" FontWeight="Bold"/>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -46,6 +46,7 @@ namespace Famille
         // Options (exposables dans Paramètres si tu veux)
         private bool useShellThumbs = true;   // ON par défaut
         private bool useRevitPreview = false;  // ON : fallback natif Revit lorsque pas d'image catalogue
+        private bool detailedViewMode = false;
 
         // ===== Données UI =====
         private List<FamilyItem> allFamilies = new();
@@ -68,6 +69,11 @@ namespace Famille
         private static readonly System.Threading.SemaphoreSlim _thumbGate = new(4);
         private static readonly Dictionary<string, ImageSource> _bitmapCache =
             new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string> _omniClassCache =
+            new(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> _omniClassPending =
+            new(StringComparer.OrdinalIgnoreCase);
+        private static readonly object _omniClassLock = new();
 
         // ===== Collections =====
         private ObservableCollection<Collection> _collections = new();
@@ -115,6 +121,7 @@ namespace Famille
 
             Famille.CatalogImageResolver.Initialize(familiesFolder, imagesFolder);
             Famille.FamilyThumbnailProvider.Initialize(FamilyBrowserCommand.uiapp);
+            Famille.FamilyMetadataProvider.Initialize(FamilyBrowserCommand.uiapp);
 
             // Arbo + Top-8
             LoadFolderTree();
@@ -163,6 +170,7 @@ namespace Famille
             allFamilies.Clear();
             displayedFamilies.Clear();
             FamilyListView.ItemsSource = displayedFamilies;
+            UpdateFamilyListViewMode();
             UpdateCount(0);
 
             RefreshTop8_UsageOnly();
@@ -252,7 +260,11 @@ namespace Famille
             TopFamiliesView.Visibility = vis;
             TopSeparator.Visibility = vis;
 
-            foreach (var it in topItems) LoadThumbnailForFamilyItem(it);
+            foreach (var it in topItems)
+            {
+                LoadThumbnailForFamilyItem(it);
+                LoadOmniClassForFamilyItem(it);
+            }
         }
 
         private void ShowTop8CheckBox_Changed(object sender, RoutedEventArgs e)
@@ -434,6 +446,7 @@ namespace Famille
             {
                 displayedFamilies.Add(item);
                 LoadThumbnailForFamilyItem(item);
+                LoadOmniClassForFamilyItem(item);
             }
 
             // rafraîchit source
@@ -652,6 +665,74 @@ namespace Famille
             });
         }
 
+        private void LoadOmniClassForFamilyItem(FamilyItem fam)
+        {
+            if (fam == null || string.IsNullOrEmpty(fam.Path)) return;
+
+            string cached;
+            lock (_omniClassLock)
+            {
+                if (_omniClassCache.TryGetValue(fam.Path, out cached))
+                {
+                    UpdateOmniClassBinding(fam, cached);
+                    return;
+                }
+
+                if (_omniClassPending.Contains(fam.Path))
+                    return;
+
+                _omniClassPending.Add(fam.Path);
+            }
+
+            if (!FamilyMetadataProvider.IsAvailable)
+            {
+                lock (_omniClassLock)
+                {
+                    _omniClassPending.Remove(fam.Path);
+                    _omniClassCache[fam.Path] = null;
+                }
+                UpdateOmniClassBinding(fam, null);
+                return;
+            }
+
+            Task.Run(async () =>
+            {
+                string number = null;
+                try
+                {
+                    number = await FamilyMetadataProvider
+                                    .RequestOmniClassNumberAsync(fam.Path)
+                                    .ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(number))
+                        number = number.Trim();
+                    else
+                        number = null;
+                }
+                catch
+                {
+                    number = null;
+                }
+
+                lock (_omniClassLock)
+                {
+                    _omniClassPending.Remove(fam.Path);
+                    _omniClassCache[fam.Path] = number;
+                }
+
+                UpdateOmniClassBinding(fam, number);
+            });
+        }
+
+        private void UpdateOmniClassBinding(FamilyItem fam, string value)
+        {
+            if (fam == null) return;
+
+            if (Dispatcher.CheckAccess())
+                fam.OmniClassNumber = value;
+            else
+                Dispatcher.Invoke(() => fam.OmniClassNumber = value);
+        }
+
 
         // Détecte si une image "catalogue" est PRÉVUE (existe sur disque) — PNG ou JPG
         private bool TryGetCatalogImagePath(string familyPath, out string imgPath)
@@ -835,6 +916,7 @@ namespace Famille
             bool dark = false;
             bool showTop8 = false;
             bool alwaysOnTop = false;
+            bool detailedView = false;
 
             if (File.Exists(configFile))
             {
@@ -849,6 +931,7 @@ namespace Famille
                     else if (line.StartsWith("DarkMode=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("DarkMode=".Length), out dark);
                     else if (line.StartsWith("ShowTop8=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("ShowTop8=".Length), out showTop8);
                     else if (line.StartsWith("AlwaysOnTop=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("AlwaysOnTop=".Length), out alwaysOnTop);
+                    else if (line.StartsWith("DetailedView=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("DetailedView=".Length), out detailedView);
                     else if (line.StartsWith("UseShellThumbs=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("UseShellThumbs=".Length), out useShellThumbs);
                     else if (line.StartsWith("UseRevitPreview=", StringComparison.OrdinalIgnoreCase)) bool.TryParse(line.Substring("UseRevitPreview=".Length), out useRevitPreview);
                 }
@@ -863,8 +946,11 @@ namespace Famille
             if (DarkModeCheckBox != null) DarkModeCheckBox.IsChecked = dark;
             if (ShowTop8CheckBox != null) ShowTop8CheckBox.IsChecked = showTop8;
             if (AlwaysOnTopCheckBox != null) AlwaysOnTopCheckBox.IsChecked = alwaysOnTop;
+            detailedViewMode = detailedView;
+            if (DetailedViewCheckBox != null) DetailedViewCheckBox.IsChecked = detailedViewMode;
 
             this.Topmost = alwaysOnTop;
+            UpdateFamilyListViewMode();
         }
 
         private void SaveConfig_Click(object s, RoutedEventArgs e)
@@ -880,6 +966,7 @@ namespace Famille
                 "DarkMode="   + ((DarkModeCheckBox?.IsChecked == true) ? "true" : "false"),
                 "ShowTop8="   + ((ShowTop8CheckBox?.IsChecked == true) ? "true" : "false"),
                 "AlwaysOnTop="+ ((AlwaysOnTopCheckBox?.IsChecked == true) ? "true" : "false"),
+                "DetailedView=" + ((DetailedViewCheckBox?.IsChecked == true) ? "true" : "false"),
                 "UseShellThumbs="  + (useShellThumbs  ? "true" : "false"),
                 "UseRevitPreview=" + (useRevitPreview ? "true" : "false"),
             };
@@ -899,6 +986,7 @@ namespace Famille
             if (DarkModeCheckBox != null) DarkModeCheckBox.IsChecked = false;
             if (ShowTop8CheckBox != null) ShowTop8CheckBox.IsChecked = false;
             if (AlwaysOnTopCheckBox != null) AlwaysOnTopCheckBox.IsChecked = false;
+            if (DetailedViewCheckBox != null) DetailedViewCheckBox.IsChecked = false;
             this.Topmost = false;
             UpdateTheme();
             SaveConfig_Click(s, e);
@@ -943,6 +1031,40 @@ namespace Famille
                 Resources["TabBackground"] = new SolidColorBrush(tabBg);
                 Resources["ImageBackground"] = new SolidColorBrush(Colors.Transparent);
                 Resources["PrimaryText"] = new SolidColorBrush(Colors.Black);
+            }
+        }
+
+        private void DetailedViewCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            detailedViewMode = DetailedViewCheckBox?.IsChecked == true;
+            UpdateFamilyListViewMode();
+        }
+
+        private void UpdateFamilyListViewMode()
+        {
+            if (FamilyListView == null) return;
+
+            var templateKey = detailedViewMode ? "FamilyItemDetailedTemplate" : "FamilyItemTemplate";
+            if (TryFindResource(templateKey) is DataTemplate template)
+            {
+                FamilyListView.ItemTemplate = template;
+            }
+
+            var panelKey = detailedViewMode ? "FamilyListStackPanel" : "FamilyListWrapPanel";
+            if (TryFindResource(panelKey) is ItemsPanelTemplate panel)
+            {
+                FamilyListView.ItemsPanel = panel;
+            }
+
+            var currentItems = displayedFamilies;
+            FamilyListView.ItemsSource = null;
+            FamilyListView.ItemsSource = currentItems;
+            FamilyListView.Items.Refresh();
+
+            if (detailedViewMode && currentItems != null)
+            {
+                foreach (var item in currentItems)
+                    LoadOmniClassForFamilyItem(item);
             }
         }
 
@@ -1192,6 +1314,13 @@ namespace Famille
         public string Path { get; set; }
         public string Category { get; set; }
         public string NormalizedName { get; set; }
+
+        private string _omniClassNumber;
+        public string OmniClassNumber
+        {
+            get => _omniClassNumber;
+            set { if (_omniClassNumber != value) { _omniClassNumber = value; OnPropertyChanged(nameof(OmniClassNumber)); } }
+        }
 
         private ImageSource _icon;
         public ImageSource Icon

--- a/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
@@ -1,0 +1,256 @@
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Famille
+{
+    internal static class FamilyMetadataProvider
+    {
+        private sealed class MetadataRequest
+        {
+            public string FamilyPath;
+            public TaskCompletionSource<string> Tcs;
+        }
+
+        private sealed class Handler : IExternalEventHandler
+        {
+            private readonly Queue<MetadataRequest> _queue;
+            public Handler(Queue<MetadataRequest> queue) => _queue = queue;
+            public string GetName() => nameof(FamilyMetadataProvider);
+
+            public void Execute(UIApplication app)
+            {
+                MetadataRequest request;
+                while ((request = Dequeue()) != null)
+                {
+                    string result = null;
+                    try
+                    {
+                        result = ExtractOmniClassNumber(app, request.FamilyPath);
+                    }
+                    catch
+                    {
+                        result = null;
+                    }
+                    request.Tcs.TrySetResult(result);
+                }
+            }
+
+            private MetadataRequest Dequeue()
+            {
+                lock (_queue)
+                {
+                    return _queue.Count > 0 ? _queue.Dequeue() : null;
+                }
+            }
+        }
+
+        private static readonly Queue<MetadataRequest> _queue = new();
+        private static ExternalEvent _eventRef;
+        private static Handler _handler;
+
+        public static bool IsAvailable => _eventRef != null;
+
+        public static void Initialize(UIApplication app)
+        {
+            if (app == null || _handler != null) return;
+
+            _handler = new Handler(_queue);
+            try
+            {
+                _eventRef = ExternalEvent.Create(_handler);
+            }
+            catch
+            {
+                _handler = null;
+                _eventRef = null;
+            }
+        }
+
+        public static Task<string> RequestOmniClassNumberAsync(string familyPath)
+        {
+            if (string.IsNullOrWhiteSpace(familyPath) || _eventRef == null)
+                return Task.FromResult<string>(null);
+
+            var request = new MetadataRequest
+            {
+                FamilyPath = familyPath,
+                Tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously)
+            };
+
+            lock (_queue)
+            {
+                _queue.Enqueue(request);
+            }
+
+            try
+            {
+                _eventRef.Raise();
+            }
+            catch
+            {
+                request.Tcs.TrySetResult(null);
+            }
+
+            return request.Tcs.Task;
+        }
+
+        private static string ExtractOmniClassNumber(UIApplication uiapp, string path)
+        {
+            if (uiapp == null || string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                return null;
+
+            if (WouldUpgrade(uiapp.Application, path))
+                return null;
+
+            Document famDoc = null;
+            try
+            {
+                famDoc = uiapp.Application.OpenDocumentFile(path);
+                if (famDoc == null || !famDoc.IsFamilyDocument)
+                    return null;
+
+                var fromFamily = ReadParameter(famDoc.OwnerFamily?.get_Parameter(BuiltInParameter.OMNICLASS_NUMBER));
+                if (!string.IsNullOrWhiteSpace(fromFamily))
+                    return fromFamily;
+
+                var symbol = new FilteredElementCollector(famDoc)
+                    .OfClass(typeof(FamilySymbol))
+                    .Cast<FamilySymbol>()
+                    .FirstOrDefault();
+
+                if (symbol != null)
+                {
+                    var fromSymbol = ReadParameter(symbol.get_Parameter(BuiltInParameter.OMNICLASS_NUMBER));
+                    if (!string.IsNullOrWhiteSpace(fromSymbol))
+                        return fromSymbol;
+                }
+
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+            finally
+            {
+                if (famDoc != null)
+                {
+                    try { famDoc.Close(false); } catch { }
+                }
+            }
+        }
+
+        private static string ReadParameter(Parameter parameter)
+        {
+            if (parameter == null) return null;
+
+            try
+            {
+                return parameter.StorageType switch
+                {
+                    StorageType.String => TrimOrNull(parameter.AsString()),
+                    StorageType.Integer => TrimOrNull(parameter.AsValueString()),
+                    StorageType.Double => TrimOrNull(parameter.AsValueString()),
+                    StorageType.ElementId => TrimOrNull(parameter.AsValueString()),
+                    _ => null
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string TrimOrNull(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return null;
+            return value.Trim();
+        }
+
+        private static bool WouldUpgrade(Application app, string rfaPath)
+        {
+            try
+            {
+                var info = BasicFileInfo.Extract(rfaPath);
+                if (info == null) return true;
+
+                int current = ParseYear(app?.VersionNumber);
+
+                if (TryGetSavedMajorVersion(info, out int saved))
+                    return saved != current;
+
+                if (TryGetYearFromProp(info, "RevitBuild", out saved) ||
+                    TryGetYearFromProp(info, "RevitProduct", out saved) ||
+                    TryGetYearFromProp(info, "Format", out saved))
+                    return saved != current;
+
+                return true;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        private static bool TryGetSavedMajorVersion(object info, out int year)
+        {
+            return
+                TryGetYearFromProp(info, "SavedInVersion", out year) ||
+                TryGetYearFromProp(info, "SavedInVersionNumber", out year) ||
+                TryGetYearFromProp(info, "SavedInVersionMajor", out year) ||
+                TryGetYearFromProp(info, "SavedIn", out year) ||
+                TryGetYearFromProp(info, "FileVersion", out year);
+        }
+
+        private static bool TryGetYearFromProp(object obj, string propName, out int year)
+        {
+            year = 0;
+            var property = obj.GetType().GetProperty(propName, BindingFlags.Public | BindingFlags.Instance);
+            if (property == null) return false;
+
+            var val = property.GetValue(obj);
+            if (val == null) return false;
+
+            if (val is int i)
+            {
+                year = NormalizeToYear(i);
+                return year >= 2008;
+            }
+
+            string s = val.ToString();
+            var m = Regex.Match(s, @"\b(20\d{2})\b");
+            if (m.Success && int.TryParse(m.Groups[1].Value, out year))
+                return true;
+
+            if (int.TryParse(s, out i))
+            {
+                year = NormalizeToYear(i);
+                return year >= 2008;
+            }
+
+            return false;
+        }
+
+        private static int NormalizeToYear(int value)
+        {
+            if (value < 100 && value >= 8) return 2000 + value;
+            return value;
+        }
+
+        private static int ParseYear(string value)
+        {
+            if (int.TryParse(value, out int v)) return NormalizeToYear(v);
+            var m = Regex.Match(value ?? string.Empty, @"\b(20\d{2})\b");
+            if (m.Success && int.TryParse(m.Groups[1].Value, out int y)) return y;
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move the detailed view checkbox into the Dossiers footer and show OmniClass numbers in the detailed template
- add an asynchronous metadata provider plus caching to retrieve each family's OmniClass number and bind it in the UI

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e67b1064d0832eadff53ad734dcb2f