### PR TITLE
Raffine la fiche détaillée du navigateur de familles

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -174,10 +174,8 @@
                                Style="{StaticResource ImageStyle}"/>
                     </Border>
 
-                    <Grid Grid.Column="1" Margin="15,0,5,0">
+                    <Grid Grid.Column="1" Margin="20,0,10,0">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -219,60 +217,183 @@
                             <TextBlock Text="{Binding Name}"
                                        Foreground="{DynamicResource PrimaryText}"
                                        FontWeight="Bold"
-                                       FontSize="16"
+                                       FontSize="18"
                                        TextWrapping="Wrap"
                                        Margin="0,0,10,0"
                                        VerticalAlignment="Center"/>
                         </DockPanel>
 
-                        <TextBlock Grid.Row="1"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Category}" Value="">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding Category}" Value="{x:Null}">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                            <Run Text="Catégorie : "/>
-                            <Run Text="{Binding Category}"/>
-                        </TextBlock>
+                        <WrapPanel Grid.Row="1" Margin="0,14,0,0">
+                            <Border Background="#FFE9EEF6"
+                                    BorderBrush="#FFC9D7F5"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="10,4"
+                                    Margin="0,0,8,8">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Category}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Category}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock Text="{Binding Category}"
+                                           Foreground="#FF1F3B57"
+                                           FontWeight="SemiBold"/>
+                            </Border>
 
-                        <TextBlock Grid.Row="2"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Version Revit : "/>
-                            <Run Text="{Binding RevitSavedVersion, TargetNullValue=—}"/>
-                        </TextBlock>
+                            <Border Background="#FFF2F5FC"
+                                    BorderBrush="#FFDCE6FA"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="10,4"
+                                    Margin="0,0,8,8">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding RevitSavedVersion}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding RevitSavedVersion}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock Foreground="#FF2A3F6A" FontWeight="SemiBold">
+                                    <Run Text="Revit "/>
+                                    <Run Text="{Binding RevitSavedVersion}"/>
+                                </TextBlock>
+                            </Border>
+
+                            <Border Background="#FFFDF2E8"
+                                    BorderBrush="#FFF6D9B8"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="10,4"
+                                    Margin="0,0,8,8">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding FileSizeText}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding FileSizeText}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock Text="{Binding FileSizeText}"
+                                           Foreground="#FF594525"
+                                           FontWeight="SemiBold"/>
+                            </Border>
+                        </WrapPanel>
+
+                        <Border Grid.Row="2"
+                                Margin="0,16,0,0"
+                                Background="#FFFFFFFF"
+                                BorderBrush="#22000000"
+                                BorderThickness="1"
+                                CornerRadius="10"
+                                Padding="18">
+                            <StackPanel>
+                                <TextBlock Text="Détails"
+                                           Foreground="#FF1F3B57"
+                                           FontWeight="SemiBold"
+                                           FontSize="14"/>
+                                <Border Height="1"
+                                        Margin="0,10,0,14"
+                                        Background="#22000000"/>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Catégorie"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding Category, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Version Revit"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding RevitSavedVersion, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Dernière mise à jour"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding LastUpdatedText, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Taille du fichier"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding FileSizeText, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Numéro OmniClass"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding OmniClassNumber, TargetNullValue=—}"/>
+                                </Grid>
+                            </StackPanel>
+                        </Border>
 
                         <TextBlock Grid.Row="3"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Dernière mise à jour : "/>
-                            <Run Text="{Binding LastUpdatedText, TargetNullValue=—}"/>
-                        </TextBlock>
-
-                        <TextBlock Grid.Row="4"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Numéro OmniClass : "/>
-                            <Run Text="{Binding OmniClassNumber, TargetNullValue=—}"/>
-                        </TextBlock>
-
-                        <TextBlock Grid.Row="5"
                                    Foreground="Gray"
-                                   Margin="0,6,0,0"
+                                   Margin="0,18,0,0"
                                    FontStyle="Italic"
                                    Text="Double-cliquer pour charger la famille"/>
                     </Grid>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -710,6 +710,8 @@ namespace Famille
                     ? null
                     : meta.OmniClassCode.Trim();
 
+                fam.FileSizeText = FormatFileSize(meta?.FileSizeBytes);
+
                 if (meta != null)
                 {
                     fam.Category = string.IsNullOrWhiteSpace(meta.Category)
@@ -743,6 +745,7 @@ namespace Famille
                     fam.RevitSavedVersion = null;
                     if (string.IsNullOrWhiteSpace(fam.Category))
                         fam.Category = null;
+                    fam.FileSizeText = null;
                 }
             }
 
@@ -750,6 +753,26 @@ namespace Famille
                 Apply();
             else
                 Dispatcher.Invoke(Apply);
+        }
+
+        private static string FormatFileSize(long? bytes)
+        {
+            if (!bytes.HasValue || bytes.Value <= 0)
+                return null;
+
+            double mb = bytes.Value / (1024d * 1024d);
+            if (mb >= 1d)
+                return string.Format(CultureInfo.CurrentCulture, "{0:N2} Mo", mb);
+
+            double kb = bytes.Value / 1024d;
+            if (kb >= 1d)
+                return string.Format(CultureInfo.CurrentCulture, "{0:N0} Ko", kb);
+
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{0} octet{1}",
+                bytes.Value,
+                bytes.Value > 1 ? "s" : string.Empty);
         }
 
 
@@ -1366,6 +1389,13 @@ namespace Famille
         {
             get => _lastUpdatedText;
             set { if (_lastUpdatedText != value) { _lastUpdatedText = value; OnPropertyChanged(nameof(LastUpdatedText)); } }
+        }
+
+        private string _fileSizeText;
+        public string FileSizeText
+        {
+            get => _fileSizeText;
+            set { if (_fileSizeText != value) { _fileSizeText = value; OnPropertyChanged(nameof(FileSizeText)); } }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
@@ -28,15 +28,7 @@ namespace Famille
         // (4) Dernière sauvegarde (gardé pour compatibilité UI)
         public DateTime? UpdatedUtc { get; set; }
 
-        // (5) Comportements clés (true/false/null si inconnu)
-        public bool? WorkPlaneBased { get; set; }
-        public bool? FaceBased { get; set; }
-        public bool? AlwaysVertical { get; set; }
-        public bool? CutWithVoidsWhenLoaded { get; set; }
-        public bool? AllowsCutInViews { get; set; }
-        public bool? Shared { get; set; }
-
-        // (8) Taille du fichier
+        // (5) Taille du fichier
         public long? FileSizeBytes { get; set; }
 
         public string Path { get; set; }
@@ -95,14 +87,6 @@ namespace Famille
         private static readonly Regex RxCategoryTerm = new Regex(@"<\s*category\s*>\s*<\s*term\s*>\s*([^<]{1,200}?)\s*</\s*term\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RxProductVersion = new Regex(@"<\s*(?:[A-Za-z0-9]+:)?product-version\s*>\s*(\d{4})\s*</\s*(?:[A-Za-z0-9]+:)?product-version\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RxUpdated = new Regex(@"<\s*updated\s*>\s*([0-9T:\-\.Z\+]+)\s*</\s*updated\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly string YesNoGroup = @"(?:(?:Oui|Yes|True)|(?:Non|No|False))";
-        private static readonly Regex RxWorkPlane = new Regex(@"Bas[ée]e\s+sur\s+le\s+plan\s+de\s+construction[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxFaceBased = new Regex(@"(Placer\s+sur\s+face|Face[-\s]*based)[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxAlwaysVertical = new Regex(@"Toujours\s+verticalement[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxCutWithVoids = new Regex(@"Couper\s+avec\s+des\s+vides\s+une\s+fois\s+charg[ée]e[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxAllowsCut = new Regex(@"Autoriser\s+la\s+d[ée]coupe\s+dans\s+les\s+vues[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxShared = new Regex(@"Partag[ée]e?[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static string ExtractOmniClassNumber(string path)
         {
@@ -236,22 +220,12 @@ namespace Famille
                             }
                         }
 
-                        // Comportements (bools)
-                        if (meta.WorkPlaneBased == null) meta.WorkPlaneBased = TryParseYesNo(text, RxWorkPlane);
-                        if (meta.FaceBased == null) meta.FaceBased = TryParseYesNo(text, RxFaceBased);
-                        if (meta.AlwaysVertical == null) meta.AlwaysVertical = TryParseYesNo(text, RxAlwaysVertical);
-                        if (meta.CutWithVoidsWhenLoaded == null) meta.CutWithVoidsWhenLoaded = TryParseYesNo(text, RxCutWithVoids);
-                        if (meta.AllowsCutInViews == null) meta.AllowsCutInViews = TryParseYesNo(text, RxAllowsCut);
-                        if (meta.Shared == null) meta.Shared = TryParseYesNo(text, RxShared);
-
                         // chevauchement
                         if (total > overlap) { Buffer.BlockCopy(buffer, total - overlap, buffer, 0, overlap); carry = overlap; }
                         else carry = total;
 
-                        // Stop anticipé si tout le principal est trouvé
-                        if (meta.OmniClassCode != null && meta.Category != null && meta.RevitSavedVersion != null &&
-                            (meta.WorkPlaneBased.HasValue || meta.FaceBased.HasValue || meta.AlwaysVertical.HasValue ||
-                             meta.CutWithVoidsWhenLoaded.HasValue || meta.AllowsCutInViews.HasValue || meta.Shared.HasValue))
+                        // Stop anticipé si l'essentiel est déjà trouvé
+                        if (meta.OmniClassCode != null && meta.Category != null && meta.RevitSavedVersion != null)
                         {
                             // on continue un peu pour tenter OmniClassTitle, sinon on pourrait break
                         }
@@ -289,16 +263,5 @@ namespace Famille
             return s;
         }
 
-        // Lit un bool "Oui/Non | Yes/No | True/False" à proximité d'un libellé.
-        private static bool? TryParseYesNo(string text, Regex pattern)
-        {
-            var m = pattern.Match(text);
-            if (!m.Success || m.Groups.Count < 2) return null;
-
-            var raw = m.Groups[m.Groups.Count - 1].Value.Trim().ToLowerInvariant();
-            if (raw.StartsWith("oui") || raw.StartsWith("yes") || raw.StartsWith("true")) return true;
-            if (raw.StartsWith("non") || raw.StartsWith("no") || raw.StartsWith("false")) return false;
-            return null;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- retire la collecte et l’exposition du résumé de comportements Revit pour simplifier les métadonnées utilisées
- réorganise la fiche détaillée avec des pastilles d’information et une carte structurée pour les détails essentiels (catégorie, version, taille, OmniClass)

## Testing
- dotnet build BIMaestro.sln *(échoue : `dotnet` absent dans l’environnement de build de la sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e793b79c94832ea9109e49e30a4386