### PR TITLE
Affiche les pastilles interactives et tri par taille

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -44,12 +44,138 @@
             </Setter>
         </Style>
 
+        <local:ChipActiveConverter x:Key="ChipActiveConverter"/>
+
+        <Style x:Key="ChipButtonBaseStyle" TargetType="Button">
+            <Setter Property="Padding" Value="10,4"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="12"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="CategoryChipStyle" TargetType="Button" BasedOn="{StaticResource ChipButtonBaseStyle}">
+            <Setter Property="Background" Value="#FFE9EEF6"/>
+            <Setter Property="BorderBrush" Value="#FFC9D7F5"/>
+            <Setter Property="Foreground" Value="#FF1F3B57"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#FFD9E3F5"/>
+                    <Setter Property="BorderBrush" Value="#FFB1C3E9"/>
+                </Trigger>
+                <DataTrigger Binding="{Binding Category}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Category}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Value="True">
+                    <DataTrigger.Binding>
+                        <MultiBinding Converter="{StaticResource ChipActiveConverter}">
+                            <Binding Path="Category"/>
+                            <Binding Path="ActiveCategoryFilter" RelativeSource="{RelativeSource AncestorType=Window}"/>
+                        </MultiBinding>
+                    </DataTrigger.Binding>
+                    <Setter Property="Background" Value="#FFCBD8F6"/>
+                    <Setter Property="BorderBrush" Value="#FF87A3E2"/>
+                    <Setter Property="Foreground" Value="#FF1C2F4D"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="VersionChipStyle" TargetType="Button" BasedOn="{StaticResource ChipButtonBaseStyle}">
+            <Setter Property="Background" Value="#FFF2F5FC"/>
+            <Setter Property="BorderBrush" Value="#FFDCE6FA"/>
+            <Setter Property="Foreground" Value="#FF2A3F6A"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#FFE4ECFA"/>
+                    <Setter Property="BorderBrush" Value="#FFC1D3F6"/>
+                </Trigger>
+                <DataTrigger Binding="{Binding RevitSavedVersion}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RevitSavedVersion}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Value="True">
+                    <DataTrigger.Binding>
+                        <MultiBinding Converter="{StaticResource ChipActiveConverter}">
+                            <Binding Path="RevitSavedVersion"/>
+                            <Binding Path="ActiveVersionFilter" RelativeSource="{RelativeSource AncestorType=Window}"/>
+                        </MultiBinding>
+                    </DataTrigger.Binding>
+                    <Setter Property="Background" Value="#FFD7E4FB"/>
+                    <Setter Property="BorderBrush" Value="#FF96B6F1"/>
+                    <Setter Property="Foreground" Value="#FF1E3162"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="SizeChipStyle" TargetType="Button" BasedOn="{StaticResource ChipButtonBaseStyle}">
+            <Setter Property="Background" Value="#FFFDF2E8"/>
+            <Setter Property="BorderBrush" Value="#FFF6D9B8"/>
+            <Setter Property="Foreground" Value="#FF594525"/>
+            <Setter Property="ToolTip" Value="Cliquer pour trier par taille (décroissant)"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#FFF7E5CF"/>
+                    <Setter Property="BorderBrush" Value="#FFE8C69E"/>
+                </Trigger>
+                <DataTrigger Binding="{Binding FileSizeText}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding FileSizeText}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsSizeSortActive, RelativeSource={RelativeSource AncestorType=Window}}" Value="True">
+                    <Setter Property="Background" Value="#FFFFE6C7"/>
+                    <Setter Property="BorderBrush" Value="#FFEDBC82"/>
+                    <Setter Property="Foreground" Value="#FF3E2A0F"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
         <!-- Vignette famille (onglet Dossiers) -->
         <DataTemplate x:Key="FamilyItemTemplate" DataType="{x:Type local:FamilyItem}">
             <Border Margin="5" Width="200"
-                    Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
                     MouseLeftButtonDown="FamilyItem_DoubleClick">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="{DynamicResource PanelBackground}"/>
+                        <Setter Property="BorderBrush" Value="#22000000"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Effect" Value="{x:Null}"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsHighlighted}" Value="True">
+                                <Setter Property="Background" Value="#FFF4F8FF"/>
+                                <Setter Property="BorderBrush" Value="#FF6AA7FF"/>
+                                <Setter Property="BorderThickness" Value="2"/>
+                                <Setter Property="Effect">
+                                    <Setter.Value>
+                                        <DropShadowEffect Color="#FF6AA7FF" ShadowDepth="0" BlurRadius="18" Opacity="0.35"/>
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
                 <Border.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Rentrer dans la famille"
@@ -135,10 +261,29 @@
 
         <DataTemplate x:Key="FamilyItemDetailedTemplate" DataType="{x:Type local:FamilyItem}">
             <Border Margin="5"
-                    Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
                     MouseLeftButtonDown="FamilyItem_DoubleClick"
                     HorizontalAlignment="Stretch">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="{DynamicResource PanelBackground}"/>
+                        <Setter Property="BorderBrush" Value="#22000000"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Effect" Value="{x:Null}"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsHighlighted}" Value="True">
+                                <Setter Property="Background" Value="#FFF4F8FF"/>
+                                <Setter Property="BorderBrush" Value="#FF6AA7FF"/>
+                                <Setter Property="BorderThickness" Value="2"/>
+                                <Setter Property="Effect">
+                                    <Setter.Value>
+                                        <DropShadowEffect Color="#FF6AA7FF" ShadowDepth="0" BlurRadius="18" Opacity="0.35"/>
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
                 <Border.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Rentrer dans la famille"
@@ -174,11 +319,8 @@
                                Style="{StaticResource ImageStyle}"/>
                     </Border>
 
-                    <Grid Grid.Column="1" Margin="15,0,5,0">
+                    <Grid Grid.Column="1" Margin="20,0,10,0">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -219,62 +361,119 @@
                             <TextBlock Text="{Binding Name}"
                                        Foreground="{DynamicResource PrimaryText}"
                                        FontWeight="Bold"
-                                       FontSize="16"
+                                       FontSize="18"
                                        TextWrapping="Wrap"
                                        Margin="0,0,10,0"
                                        VerticalAlignment="Center"/>
                         </DockPanel>
 
-                        <TextBlock Grid.Row="1"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Category}" Value="">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding Category}" Value="{x:Null}">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                            <Run Text="Catégorie : "/>
-                            <Run Text="{Binding Category}"/>
-                        </TextBlock>
+                        <WrapPanel Grid.Row="1" Margin="0,10,0,0">
+                            <Button Style="{StaticResource CategoryChipStyle}"
+                                    Content="{Binding Category}"
+                                    Click="CategoryChip_Click"/>
 
-                        <TextBlock Grid.Row="2"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Version Revit : "/>
-                            <Run Text="{Binding RevitSavedVersion, TargetNullValue=—}"/>
-                        </TextBlock>
+                            <Button Style="{StaticResource VersionChipStyle}"
+                                    Content="{Binding RevitSavedVersion, StringFormat=Revit {0}}"
+                                    Click="VersionChip_Click"/>
 
-                        <TextBlock Grid.Row="3"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Dernière mise à jour : "/>
-                            <Run Text="{Binding LastUpdatedText, TargetNullValue=—}"/>
-                        </TextBlock>
+                            <Button Style="{StaticResource SizeChipStyle}"
+                                    Content="{Binding FileSizeText}"
+                                    Click="SizeChip_Click"/>
+                        </WrapPanel>
 
-                        <TextBlock Grid.Row="4"
-                                   Foreground="{DynamicResource PrimaryText}"
-                                   Margin="0,6,0,0"
-                                   TextWrapping="Wrap">
-                            <Run Text="Numéro OmniClass : "/>
-                            <Run Text="{Binding OmniClassNumber, TargetNullValue=—}"/>
-                        </TextBlock>
+                        <Border Grid.Row="2"
+                                Margin="0,10,0,0"
+                                Background="#FFFFFFFF"
+                                BorderBrush="#22000000"
+                                BorderThickness="1"
+                                CornerRadius="10"
+                                Padding="18">
+                            <StackPanel>
+                                <TextBlock Text="Détails"
+                                           Foreground="#FF1F3B57"
+                                           FontWeight="SemiBold"
+                                           FontSize="14"/>
+                                <Border Height="1"
+                                        Margin="0,10,0,14"
+                                        Background="#22000000"/>
 
-                        <TextBlock Grid.Row="5"
-                                   Foreground="Gray"
-                                   Margin="0,6,0,0"
-                                   FontStyle="Italic"
-                                   Text="Double-cliquer pour charger la famille"/>
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Catégorie"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding Category, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Version Revit"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding RevitSavedVersion, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Dernière mise à jour"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding LastUpdatedText, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid Margin="0,0,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Taille du fichier"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding FileSizeText, TargetNullValue=—}"/>
+                                </Grid>
+
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="18"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Foreground="#FF6C7A92"
+                                               FontWeight="SemiBold"
+                                               Text="Numéro OmniClass"/>
+                                    <TextBlock Grid.Column="2"
+                                               Foreground="#FF1F3B57"
+                                               Text="{Binding OmniClassNumber, TargetNullValue=—}"/>
+                                </Grid>
+                            </StackPanel>
+                        </Border>
+
                     </Grid>
                 </Grid>
             </Border>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -22,7 +23,7 @@ using WinForms = System.Windows.Forms;
 
 namespace Famille
 {
-    public partial class FamilyBrowserWindow : Window
+    public partial class FamilyBrowserWindow : Window, INotifyPropertyChanged
     {
         // ===== Constantes =====
         private const string FavoritesCollectionId = "builtin_favoris";
@@ -54,6 +55,9 @@ namespace Famille
         private string currentFolderPath;
 
         public string RootFolderName => System.IO.Path.GetFileName(rootFolderPath);
+        public string ActiveCategoryFilter => _activeCategoryFilter;
+        public string ActiveVersionFilter => _activeVersionFilter;
+        public bool IsSizeSortActive => _isSizeSortActive;
 
         // Pagination & recherche
         private const int PageSize = 200;
@@ -74,6 +78,11 @@ namespace Famille
         private static readonly HashSet<string> _metadataPending =
             new(StringComparer.OrdinalIgnoreCase);
         private static readonly object _metadataLock = new();
+
+        private string _activeCategoryFilter;
+        private string _activeVersionFilter;
+        private bool _isSizeSortActive;
+        private bool _pendingSizeResort;
 
         // ===== Collections =====
         private ObservableCollection<Collection> _collections = new();
@@ -206,6 +215,8 @@ namespace Famille
 
         private void LoadFamilies(string path, bool recursive)
         {
+            ClearChipFilters();
+
             allFamilies.Clear();
             var opt = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
@@ -221,6 +232,9 @@ namespace Famille
                     return (f.Name, int.MaxValue);
                 })
                 .ToList();
+
+            for (int i = 0; i < allFamilies.Count; i++)
+                allFamilies[i].NaturalOrder = i;
 
             TopFamiliesView.Visibility = Visibility.Collapsed;
             TopSeparator.Visibility = Visibility.Collapsed;
@@ -261,6 +275,8 @@ namespace Famille
                 LoadThumbnailForFamilyItem(it);
                 LoadMetadataForFamilyItem(it);
             }
+
+            ApplyActiveHighlights();
         }
 
         private void ShowTop8CheckBox_Changed(object sender, RoutedEventArgs e)
@@ -336,6 +352,214 @@ namespace Famille
 
         #endregion
 
+        #region Pastilles interactives
+
+        private void CategoryChip_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.DataContext is not FamilyItem fam) return;
+
+            var target = fam.Category;
+            if (EqualsIgnoreCase(_activeCategoryFilter, target))
+                SetActiveCategoryFilter(null, applyHighlights: true);
+            else
+                SetActiveCategoryFilter(target, applyHighlights: true);
+
+            e.Handled = true;
+        }
+
+        private void VersionChip_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.DataContext is not FamilyItem fam) return;
+
+            var target = fam.RevitSavedVersion;
+            if (EqualsIgnoreCase(_activeVersionFilter, target))
+                SetActiveVersionFilter(null, applyHighlights: true);
+            else
+                SetActiveVersionFilter(target, applyHighlights: true);
+
+            e.Handled = true;
+        }
+
+        private void SizeChip_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.DataContext is not FamilyItem fam) return;
+
+            // assure la récupération du poids même si les métadonnées ne sont pas encore là
+            if (!_isSizeSortActive)
+                _ = GetFileSizeValue(fam);
+
+            SetSizeSortActive(!_isSizeSortActive, applySort: true);
+            e.Handled = true;
+        }
+
+        private void ClearChipFilters()
+        {
+            SetActiveCategoryFilter(null, applyHighlights: false);
+            SetActiveVersionFilter(null, applyHighlights: false);
+            SetSizeSortActive(false, applySort: false);
+            ApplyActiveHighlights();
+        }
+
+        private void SetActiveCategoryFilter(string category, bool applyHighlights)
+        {
+            string normalized = NormalizeFilterValue(category);
+            if (EqualsIgnoreCase(_activeCategoryFilter, normalized))
+            {
+                if (applyHighlights) ApplyActiveHighlights();
+                return;
+            }
+
+            _activeCategoryFilter = normalized;
+            OnPropertyChanged(nameof(ActiveCategoryFilter));
+            if (applyHighlights) ApplyActiveHighlights();
+        }
+
+        private void SetActiveVersionFilter(string version, bool applyHighlights)
+        {
+            string normalized = NormalizeFilterValue(version);
+            if (EqualsIgnoreCase(_activeVersionFilter, normalized))
+            {
+                if (applyHighlights) ApplyActiveHighlights();
+                return;
+            }
+
+            _activeVersionFilter = normalized;
+            OnPropertyChanged(nameof(ActiveVersionFilter));
+            if (applyHighlights) ApplyActiveHighlights();
+        }
+
+        private void SetSizeSortActive(bool active, bool applySort)
+        {
+            if (_isSizeSortActive == active)
+            {
+                if (applySort) ApplySizeSort();
+                return;
+            }
+
+            _isSizeSortActive = active;
+            OnPropertyChanged(nameof(IsSizeSortActive));
+            if (!active)
+                _pendingSizeResort = false;
+
+            if (applySort)
+                ApplySizeSort();
+        }
+
+        private void ApplyActiveHighlights()
+        {
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(ApplyActiveHighlights);
+                return;
+            }
+
+            if (displayedFamilies != null)
+            {
+                foreach (var fam in displayedFamilies)
+                    fam.IsHighlighted = ShouldHighlight(fam);
+            }
+
+            if (TopFamiliesView?.ItemsSource is IEnumerable<FamilyItem> topItems)
+            {
+                foreach (var fam in topItems)
+                    fam.IsHighlighted = ShouldHighlight(fam);
+            }
+        }
+
+        private void ApplyHighlightToItem(FamilyItem fam)
+        {
+            if (fam == null) return;
+            fam.IsHighlighted = ShouldHighlight(fam);
+        }
+
+        private bool ShouldHighlight(FamilyItem fam)
+        {
+            if (fam == null) return false;
+
+            bool matchesCategory = !string.IsNullOrWhiteSpace(_activeCategoryFilter) &&
+                                   EqualsIgnoreCase(fam.Category, _activeCategoryFilter);
+            bool matchesVersion = !string.IsNullOrWhiteSpace(_activeVersionFilter) &&
+                                  EqualsIgnoreCase(fam.RevitSavedVersion, _activeVersionFilter);
+
+            return matchesCategory || matchesVersion;
+        }
+
+        private static bool EqualsIgnoreCase(string left, string right)
+        {
+            if (left == null && right == null) return true;
+            if (left == null || right == null) return false;
+            return string.Equals(left.Trim(), right.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeFilterValue(string value)
+            => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        private void ApplySizeSort()
+        {
+            if (_currentResult == null) return;
+
+            var source = _currentResult.ToList();
+            List<FamilyItem> ordered;
+
+            if (_isSizeSortActive)
+            {
+                ordered = source
+                    .OrderByDescending(GetFileSizeValue)
+                    .ThenBy(f => f.NaturalOrder)
+                    .ToList();
+            }
+            else
+            {
+                ordered = source
+                    .OrderBy(f => f.NaturalOrder)
+                    .ToList();
+            }
+
+            BeginPaging(ordered);
+        }
+
+        private long GetFileSizeValue(FamilyItem fam)
+        {
+            if (fam == null) return long.MinValue;
+
+            if (fam.FileSizeBytes.HasValue)
+                return fam.FileSizeBytes.Value;
+
+            lock (_metadataLock)
+            {
+                if (_metadataCache.TryGetValue(fam.Path, out var meta) && meta?.FileSizeBytes.HasValue == true)
+                {
+                    fam.FileSizeBytes = meta.FileSizeBytes;
+                    return meta.FileSizeBytes.Value;
+                }
+            }
+
+            try
+            {
+                var info = new FileInfo(fam.Path);
+                fam.FileSizeBytes = info.Length;
+                return info.Length;
+            }
+            catch
+            {
+                return long.MinValue;
+            }
+        }
+
+        private void RequestSizeResort()
+        {
+            if (!_isSizeSortActive || _pendingSizeResort) return;
+
+            _pendingSizeResort = true;
+            Dispatcher.InvokeAsync(() =>
+            {
+                _pendingSizeResort = false;
+                ApplySizeSort();
+            }, DispatcherPriority.Background);
+        }
+
+        #endregion
+
         #region Recherche + pagination
 
         private void SearchBox_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
@@ -388,12 +612,13 @@ namespace Famille
                 }
 
                 var hits = _index.Search(txt, max: 8000);
-                var items = hits.Select(e => new FamilyItem
+                var items = hits.Select((e, idx) => new FamilyItem
                 {
                     Name = e.Name,
                     Path = e.Path,
                     Category = e.Category,
-                    NormalizedName = e.NormalizedName
+                    NormalizedName = e.NormalizedName,
+                    NaturalOrder = idx
                 }).ToList();
 
                 BeginPaging(items);
@@ -438,6 +663,7 @@ namespace Famille
             foreach (var item in slice)
             {
                 displayedFamilies.Add(item);
+                ApplyHighlightToItem(item);
                 LoadThumbnailForFamilyItem(item);
                 LoadMetadataForFamilyItem(item);
             }
@@ -448,6 +674,8 @@ namespace Famille
 
             // Met à jour les étoiles selon la collection Favoris
             MarkFavoritesInView(displayedFamilies);
+
+            ApplyActiveHighlights();
 
             PagingStatusText.Text = _nextIndex >= _currentResult.Count
                 ? "Fin de la liste."
@@ -710,6 +938,9 @@ namespace Famille
                     ? null
                     : meta.OmniClassCode.Trim();
 
+                fam.FileSizeText = FormatFileSize(meta?.FileSizeBytes);
+                fam.FileSizeBytes = meta?.FileSizeBytes;
+
                 if (meta != null)
                 {
                     fam.Category = string.IsNullOrWhiteSpace(meta.Category)
@@ -743,13 +974,39 @@ namespace Famille
                     fam.RevitSavedVersion = null;
                     if (string.IsNullOrWhiteSpace(fam.Category))
                         fam.Category = null;
+                    fam.FileSizeText = null;
+                    fam.FileSizeBytes = null;
                 }
+
+                ApplyHighlightToItem(fam);
+                if (meta?.FileSizeBytes.HasValue == true)
+                    RequestSizeResort();
             }
 
             if (Dispatcher.CheckAccess())
                 Apply();
             else
                 Dispatcher.Invoke(Apply);
+        }
+
+        private static string FormatFileSize(long? bytes)
+        {
+            if (!bytes.HasValue || bytes.Value <= 0)
+                return null;
+
+            double mb = bytes.Value / (1024d * 1024d);
+            if (mb >= 1d)
+                return string.Format(CultureInfo.CurrentCulture, "{0:N2} Mo", mb);
+
+            double kb = bytes.Value / 1024d;
+            if (kb >= 1d)
+                return string.Format(CultureInfo.CurrentCulture, "{0:N0} Ko", kb);
+
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{0} octet{1}",
+                bytes.Value,
+                bytes.Value > 1 ? "s" : string.Empty);
         }
 
 
@@ -1302,6 +1559,15 @@ namespace Famille
 
         #endregion
 
+        #region INotifyPropertyChanged
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        #endregion
+
         #region Modèle
 
         private FamilyItem CreateFamilyItemFromPath(string path)
@@ -1368,8 +1634,50 @@ namespace Famille
             set { if (_lastUpdatedText != value) { _lastUpdatedText = value; OnPropertyChanged(nameof(LastUpdatedText)); } }
         }
 
+        private string _fileSizeText;
+        public string FileSizeText
+        {
+            get => _fileSizeText;
+            set { if (_fileSizeText != value) { _fileSizeText = value; OnPropertyChanged(nameof(FileSizeText)); } }
+        }
+
+        private long? _fileSizeBytes;
+        public long? FileSizeBytes
+        {
+            get => _fileSizeBytes;
+            set { if (_fileSizeBytes != value) { _fileSizeBytes = value; OnPropertyChanged(nameof(FileSizeBytes)); } }
+        }
+
+        private bool _isHighlighted;
+        public bool IsHighlighted
+        {
+            get => _isHighlighted;
+            set { if (_isHighlighted != value) { _isHighlighted = value; OnPropertyChanged(nameof(IsHighlighted)); } }
+        }
+
+        public int NaturalOrder { get; set; }
+
         public event PropertyChangedEventHandler PropertyChanged;
         protected void OnPropertyChanged(string propName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
+    }
+
+    public class ChipActiveConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2) return false;
+
+            var value = values[0] as string;
+            var active = values[1] as string;
+
+            if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(active))
+                return false;
+
+            return string.Equals(value.Trim(), active.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
     }
 }

--- a/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyMetadataProvider.cs
@@ -28,15 +28,7 @@ namespace Famille
         // (4) Dernière sauvegarde (gardé pour compatibilité UI)
         public DateTime? UpdatedUtc { get; set; }
 
-        // (5) Comportements clés (true/false/null si inconnu)
-        public bool? WorkPlaneBased { get; set; }
-        public bool? FaceBased { get; set; }
-        public bool? AlwaysVertical { get; set; }
-        public bool? CutWithVoidsWhenLoaded { get; set; }
-        public bool? AllowsCutInViews { get; set; }
-        public bool? Shared { get; set; }
-
-        // (8) Taille du fichier
+        // (5) Taille du fichier
         public long? FileSizeBytes { get; set; }
 
         public string Path { get; set; }
@@ -95,14 +87,6 @@ namespace Famille
         private static readonly Regex RxCategoryTerm = new Regex(@"<\s*category\s*>\s*<\s*term\s*>\s*([^<]{1,200}?)\s*</\s*term\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RxProductVersion = new Regex(@"<\s*(?:[A-Za-z0-9]+:)?product-version\s*>\s*(\d{4})\s*</\s*(?:[A-Za-z0-9]+:)?product-version\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RxUpdated = new Regex(@"<\s*updated\s*>\s*([0-9T:\-\.Z\+]+)\s*</\s*updated\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly string YesNoGroup = @"(?:(?:Oui|Yes|True)|(?:Non|No|False))";
-        private static readonly Regex RxWorkPlane = new Regex(@"Bas[ée]e\s+sur\s+le\s+plan\s+de\s+construction[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxFaceBased = new Regex(@"(Placer\s+sur\s+face|Face[-\s]*based)[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxAlwaysVertical = new Regex(@"Toujours\s+verticalement[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxCutWithVoids = new Regex(@"Couper\s+avec\s+des\s+vides\s+une\s+fois\s+charg[ée]e[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxAllowsCut = new Regex(@"Autoriser\s+la\s+d[ée]coupe\s+dans\s+les\s+vues[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RxShared = new Regex(@"Partag[ée]e?[^<>]{0,80}(" + YesNoGroup + ")", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static string ExtractOmniClassNumber(string path)
         {
@@ -236,22 +220,12 @@ namespace Famille
                             }
                         }
 
-                        // Comportements (bools)
-                        if (meta.WorkPlaneBased == null) meta.WorkPlaneBased = TryParseYesNo(text, RxWorkPlane);
-                        if (meta.FaceBased == null) meta.FaceBased = TryParseYesNo(text, RxFaceBased);
-                        if (meta.AlwaysVertical == null) meta.AlwaysVertical = TryParseYesNo(text, RxAlwaysVertical);
-                        if (meta.CutWithVoidsWhenLoaded == null) meta.CutWithVoidsWhenLoaded = TryParseYesNo(text, RxCutWithVoids);
-                        if (meta.AllowsCutInViews == null) meta.AllowsCutInViews = TryParseYesNo(text, RxAllowsCut);
-                        if (meta.Shared == null) meta.Shared = TryParseYesNo(text, RxShared);
-
                         // chevauchement
                         if (total > overlap) { Buffer.BlockCopy(buffer, total - overlap, buffer, 0, overlap); carry = overlap; }
                         else carry = total;
 
-                        // Stop anticipé si tout le principal est trouvé
-                        if (meta.OmniClassCode != null && meta.Category != null && meta.RevitSavedVersion != null &&
-                            (meta.WorkPlaneBased.HasValue || meta.FaceBased.HasValue || meta.AlwaysVertical.HasValue ||
-                             meta.CutWithVoidsWhenLoaded.HasValue || meta.AllowsCutInViews.HasValue || meta.Shared.HasValue))
+                        // Stop anticipé si l'essentiel est déjà trouvé
+                        if (meta.OmniClassCode != null && meta.Category != null && meta.RevitSavedVersion != null)
                         {
                             // on continue un peu pour tenter OmniClassTitle, sinon on pourrait break
                         }
@@ -289,16 +263,5 @@ namespace Famille
             return s;
         }
 
-        // Lit un bool "Oui/Non | Yes/No | True/False" à proximité d'un libellé.
-        private static bool? TryParseYesNo(string text, Regex pattern)
-        {
-            var m = pattern.Match(text);
-            if (!m.Success || m.Groups.Count < 2) return null;
-
-            var raw = m.Groups[m.Groups.Count - 1].Value.Trim().ToLowerInvariant();
-            if (raw.StartsWith("oui") || raw.StartsWith("yes") || raw.StartsWith("true")) return true;
-            if (raw.StartsWith("non") || raw.StartsWith("no") || raw.StartsWith("false")) return false;
-            return null;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- retire la collecte et l’exposition du résumé de comportements Revit pour simplifier les métadonnées utilisées
- réorganise la fiche détaillée avec des pastilles d’information et une carte structurée pour les détails essentiels (catégorie, version, taille, OmniClass)
- rend les pastilles interactives pour filtrer ou trier la liste courante (catégorie, version, taille), accentue visuellement les familles correspondantes et allège la mise en page

## Testing
- dotnet build BIMaestro.sln *(échoue : `dotnet` absent dans l’environnement de build de la sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e793b79c94832ea9109e49e30a4386