### PR TITLE
Suspend ghost tracking during 3D preview on Revit 2025

### DIFF
--- a/BIMaestro/animation touche/Fantome oui-non/fantome.xaml.cs
+++ b/BIMaestro/animation touche/Fantome oui-non/fantome.xaml.cs
@@ -96,12 +96,29 @@ namespace BIMaestro.UI
         private double _eyeBaseX; // yeux centrés en hauteur
         private double _armBaseX;
         private Window? _hostWindow;
+        private FrameworkElement? _followScope;
 
-        private bool _appHooked;     // InputManager PreProcessInput (global)
+        private bool _windowHooked;  // MouseMove hook on the host window
+        private bool _scopeHooked;   // MouseMove hook on le scope suivi
         private bool _localHooked;   // sur ToggleHit (local)
+        private bool _trackingSuspended;
         private DateTime _lastEyeUpdate = DateTime.MinValue;
 
         public CornerRadius TrackCornerRadius => new CornerRadius(TrackHeight / 2.0);
+
+        public FrameworkElement? FollowScope
+        {
+            get => _followScope;
+            set
+            {
+                if (ReferenceEquals(_followScope, value)) return;
+                _followScope = value;
+                if (IsLoaded)
+                {
+                    ConfigureMouseHooks(reset: true);
+                }
+            }
+        }
 
         // ----- lifecycle -----
         private static void OnSizeDpChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -153,11 +170,27 @@ namespace BIMaestro.UI
         {
             if (reset)
             {
-                if (_appHooked)
+                if (_windowHooked && _hostWindow != null)
                 {
-                    try { InputManager.Current.PreProcessInput -= OnPreProcessInput; } catch { }
-                    _appHooked = false;
+                    try
+                    {
+                        WeakEventManager<Window, MouseEventArgs>.RemoveHandler(_hostWindow, nameof(_hostWindow.MouseMove), OnWindowMouseMove);
+                        WeakEventManager<Window, MouseEventArgs>.RemoveHandler(_hostWindow, nameof(_hostWindow.MouseLeave), OnWindowMouseLeave);
+                    }
+                    catch { }
+                    _windowHooked = false;
                 }
+                if (_scopeHooked && _followScope != null)
+                {
+                    try
+                    {
+                        WeakEventManager<UIElement, MouseEventArgs>.RemoveHandler(_followScope, nameof(UIElement.MouseMove), OnScopeMouseMove);
+                        WeakEventManager<UIElement, MouseEventArgs>.RemoveHandler(_followScope, nameof(UIElement.MouseLeave), OnScopeMouseLeave);
+                    }
+                    catch { }
+                    _scopeHooked = false;
+                }
+
                 if (_localHooked)
                 {
                     try
@@ -170,18 +203,49 @@ namespace BIMaestro.UI
                 }
             }
 
-            if (!attach || !IsVisible) return; // <<< ne rien accrocher si pas visible
+            if (!attach || !IsVisible || _trackingSuspended) return; // <<< ne rien accrocher si pas visible ou suspendu
 
             if (EyeFollowGlobal)
             {
-                InputManager.Current.PreProcessInput += OnPreProcessInput;
-                _appHooked = true;
+                if (_followScope != null)
+                {
+                    WeakEventManager<UIElement, MouseEventArgs>.AddHandler(_followScope, nameof(UIElement.MouseMove), OnScopeMouseMove);
+                    WeakEventManager<UIElement, MouseEventArgs>.AddHandler(_followScope, nameof(UIElement.MouseLeave), OnScopeMouseLeave);
+                    _scopeHooked = true;
+                }
+                else
+                {
+                    _hostWindow ??= Window.GetWindow(this);
+                    if (_hostWindow != null)
+                    {
+                        WeakEventManager<Window, MouseEventArgs>.AddHandler(_hostWindow, nameof(_hostWindow.MouseMove), OnWindowMouseMove);
+                        WeakEventManager<Window, MouseEventArgs>.AddHandler(_hostWindow, nameof(_hostWindow.MouseLeave), OnWindowMouseLeave);
+                        _windowHooked = true;
+                    }
+                }
             }
             else if (EyeFollowCursor)
             {
                 WeakEventManager<UIElement, MouseEventArgs>.AddHandler(ToggleHit, nameof(ToggleHit.MouseMove), OnLocalMouseMove);
                 WeakEventManager<UIElement, MouseEventArgs>.AddHandler(ToggleHit, nameof(ToggleHit.MouseLeave), OnLocalMouseLeave);
                 _localHooked = true;
+            }
+        }
+
+        public void SetTrackingSuspended(bool suspended)
+        {
+            if (_trackingSuspended == suspended) return;
+
+            _trackingSuspended = suspended;
+
+            if (suspended)
+            {
+                ConfigureMouseHooks(reset: true, attach: false);
+                ResetEyes();
+            }
+            else if (IsLoaded)
+            {
+                ConfigureMouseHooks(reset: true, attach: true);
             }
         }
 
@@ -290,8 +354,8 @@ namespace BIMaestro.UI
             { To = +_armBaseX + armLag, Duration = TimeSpan.FromMilliseconds(280), EasingFunction = ease2 });
         }
 
-        // ====== Suivi global via InputManager (application) ======
-        private void OnPreProcessInput(object? sender, PreProcessInputEventArgs e)
+        // ====== Suivi global via événements de la fenêtre ======
+        private void OnWindowMouseMove(object? sender, MouseEventArgs e)
         {
             if (!EyeFollowGlobal || (EyeLookAmount <= 0 && EyeLookAmountY <= 0)) return;
 
@@ -301,11 +365,11 @@ namespace BIMaestro.UI
 
             if (!IsLoaded || !IsVisible) return;
 
-            var win = _hostWindow ?? Window.GetWindow(this);
+            var win = (sender as Window) ?? _hostWindow ?? Window.GetWindow(this);
             if (win == null) return;
 
             Point p;
-            try { p = Mouse.GetPosition(win); } catch { return; }
+            try { p = e.GetPosition(win); } catch { return; }
 
             if (p.X < 0 || p.Y < 0 || p.X > win.ActualWidth || p.Y > win.ActualHeight)
             {
@@ -313,8 +377,37 @@ namespace BIMaestro.UI
                 return;
             }
 
-            UpdateEyeTargetFromPointInWindow(p, win);
+            UpdateEyeTargetFromRelativePoint(win, p);
         }
+
+        private void OnWindowMouseLeave(object? sender, MouseEventArgs e) => ResetEyes();
+
+        private void OnScopeMouseMove(object? sender, MouseEventArgs e)
+        {
+            if (!EyeFollowGlobal || (EyeLookAmount <= 0 && EyeLookAmountY <= 0)) return;
+
+            var now = DateTime.UtcNow;
+            if ((now - _lastEyeUpdate).TotalMilliseconds < 16) return;
+            _lastEyeUpdate = now;
+
+            if (!IsLoaded || !IsVisible) return;
+
+            if (sender is not FrameworkElement scope) return;
+
+            Point p;
+            try { p = e.GetPosition(scope); }
+            catch { return; }
+
+            if (p.X < 0 || p.Y < 0 || p.X > scope.ActualWidth || p.Y > scope.ActualHeight)
+            {
+                ResetEyes();
+                return;
+            }
+
+            UpdateEyeTargetFromRelativePoint(scope, p);
+        }
+
+        private void OnScopeMouseLeave(object? sender, MouseEventArgs e) => ResetEyes();
 
         // ====== Fallback local (survol) ======
         private void OnLocalMouseMove(object? sender, MouseEventArgs e)
@@ -332,14 +425,14 @@ namespace BIMaestro.UI
         private void OnLocalMouseLeave(object? s, MouseEventArgs e) => ResetEyes();
 
         // ====== Utilitaires regard ======
-        private void UpdateEyeTargetFromPointInWindow(Point pWindow, Window win)
+        private void UpdateEyeTargetFromRelativePoint(Visual relativeTo, Point point)
         {
             try
             {
-                var gt = Ghost.TransformToAncestor(win);
+                var gt = Ghost.TransformToAncestor(relativeTo);
                 var rect = gt.TransformBounds(new Rect(0, 0, Ghost.ActualWidth, Ghost.ActualHeight));
                 var center = new Point(rect.Left + rect.Width / 2.0, rect.Top + rect.Height / 2.0);
-                UpdateEyesFromVector(new Point(pWindow.X - center.X, pWindow.Y - center.Y), rect.Width, rect.Height);
+                UpdateEyesFromVector(new Point(point.X - center.X, point.Y - center.Y), rect.Width, rect.Height);
             }
             catch { /* visuel pas dans l’arbre → ignorer */ }
         }

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -501,7 +501,9 @@
     </Window.Resources>
 
     <Grid Background="{DynamicResource BackgroundGradient}">
-        <TabControl Background="{DynamicResource TabBackground}">
+        <TabControl x:Name="MainTabControl"
+                    Background="{DynamicResource TabBackground}"
+                    SelectionChanged="MainTabControl_SelectionChanged">
 
             <!-- Onglet Dossiers -->
             <TabItem Header="Dossiers" Background="{DynamicResource TabBackground}">
@@ -663,8 +665,10 @@
             </TabItem>
 
             <!-- Onglet Paramètres -->
-            <TabItem Header="Paramètres" Background="{DynamicResource TabBackground}">
-                <Grid Margin="12,10,8,10" Background="Transparent">
+            <TabItem x:Name="SettingsTabItem"
+                     Header="Paramètres"
+                     Background="{DynamicResource TabBackground}">
+                <Grid x:Name="SettingsPanelRoot" Margin="12,10,8,10" Background="Transparent">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -726,9 +730,12 @@
 
                     <StackPanel Orientation="Horizontal" Grid.Row="8" Margin="0,6,0,5">
                         <TextBlock Text="Toujours au-dessus :" VerticalAlignment="Center" Margin="0,0,10,0" Foreground="{DynamicResource PrimaryText}"/>
-                        <CheckBox x:Name="AlwaysOnTopCheckBox"
-                                  Checked="AlwaysOnTopCheckBox_Changed"
-                                  Unchecked="AlwaysOnTopCheckBox_Changed"/>
+                        <ui:GhostSwitch x:Name="AlwaysOnTopSwitch"
+                                        Width="130"
+                                        Height="46"
+                                        EyeFollowGlobal="False"
+                                        AutoPauseWhenHidden="True"
+                                        Toggled="AlwaysOnTopSwitch_Toggled"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Grid.Row="9" Margin="0,10,0,10">

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -57,6 +57,7 @@ namespace Famille
         private List<FamilyItem> allFamilies = new();
         private List<FamilyItem> displayedFamilies = new();
         private string currentFolderPath;
+        private readonly int _revitMajorVersion;
 
         public string RootFolderName => System.IO.Path.GetFileName(rootFolderPath);
 
@@ -117,6 +118,21 @@ namespace Famille
             InitializeComponent();
             DataContext = this;
 
+            if (FamilyBrowserCommand.uiapp?.Application?.VersionNumber != null &&
+                int.TryParse(FamilyBrowserCommand.uiapp.Application.VersionNumber, out var major))
+            {
+                _revitMajorVersion = major;
+            }
+
+            FamilyPreviewBridge.PreviewVisibilityChanged += OnPreviewVisibilityChanged;
+
+            if (AlwaysOnTopSwitch != null)
+            {
+                AlwaysOnTopSwitch.FollowScope = SettingsPanelRoot;
+            }
+
+            UpdateGhostFollowMode();
+
             LoadSavedPaths();
 
 
@@ -138,6 +154,12 @@ namespace Famille
 
             _index = new FamilyIndexService(familiesFolder, imagesFolder);
             _index.IndexUpdated += OnIndexUpdated;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            FamilyPreviewBridge.PreviewVisibilityChanged -= OnPreviewVisibilityChanged;
+            base.OnClosed(e);
         }
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)
@@ -162,6 +184,7 @@ namespace Famille
             PlaceholderText.Visibility = Visibility.Visible;
 
             // Index
+            UpdateGhostFollowMode();
             await _index.StartAsync();
         }
 
@@ -1238,7 +1261,7 @@ namespace Famille
             TabBackgroundPicker.SelectedColor = ColorFromHex(tabBg);
             if (DarkModeCheckBox != null) DarkModeCheckBox.IsChecked = dark;
             if (ShowTop8CheckBox != null) ShowTop8CheckBox.IsChecked = showTop8;
-            if (AlwaysOnTopCheckBox != null) AlwaysOnTopCheckBox.IsChecked = alwaysOnTop;
+            if (AlwaysOnTopSwitch != null) AlwaysOnTopSwitch.IsOn = alwaysOnTop;
             detailedViewMode = detailedView;
             if (DetailedViewCheckBox != null) DetailedViewCheckBox.IsChecked = detailedViewMode;
 
@@ -1258,7 +1281,7 @@ namespace Famille
                 "TabBackground="      + (TabBackgroundPicker.SelectedColor   == Colors.Transparent ? "Transparent" : ColorToHex(TabBackgroundPicker.SelectedColor.Value)),
                 "DarkMode="   + ((DarkModeCheckBox?.IsChecked == true) ? "true" : "false"),
                 "ShowTop8="   + ((ShowTop8CheckBox?.IsChecked == true) ? "true" : "false"),
-                "AlwaysOnTop="+ ((AlwaysOnTopCheckBox?.IsChecked == true) ? "true" : "false"),
+                "AlwaysOnTop="+ ((AlwaysOnTopSwitch?.IsOn == true) ? "true" : "false"),
                 "DetailedView=" + ((DetailedViewCheckBox?.IsChecked == true) ? "true" : "false"),
                 "UseShellThumbs="  + (useShellThumbs  ? "true" : "false"),
                 "UseRevitPreview=" + (useRevitPreview ? "true" : "false"),
@@ -1278,7 +1301,7 @@ namespace Famille
             TabBackgroundPicker.SelectedColor = Colors.Transparent;
             if (DarkModeCheckBox != null) DarkModeCheckBox.IsChecked = false;
             if (ShowTop8CheckBox != null) ShowTop8CheckBox.IsChecked = false;
-            if (AlwaysOnTopCheckBox != null) AlwaysOnTopCheckBox.IsChecked = false;
+            if (AlwaysOnTopSwitch != null) AlwaysOnTopSwitch.IsOn = false;
             if (DetailedViewCheckBox != null) DetailedViewCheckBox.IsChecked = false;
             this.Topmost = false;
             UpdateTheme();
@@ -1569,9 +1592,42 @@ namespace Famille
             }
         }
 
-        private void AlwaysOnTopCheckBox_Changed(object sender, RoutedEventArgs e)
+        private void AlwaysOnTopSwitch_Toggled(object sender, RoutedPropertyChangedEventArgs<bool> e)
         {
-            this.Topmost = AlwaysOnTopCheckBox?.IsChecked == true;
+            this.Topmost = AlwaysOnTopSwitch?.IsOn == true;
+        }
+
+        private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!ReferenceEquals(sender, e.OriginalSource)) return;
+            UpdateGhostFollowMode();
+        }
+
+        private void UpdateGhostFollowMode()
+        {
+            if (AlwaysOnTopSwitch == null) return;
+            bool isSettingsTabVisible = SettingsTabItem?.IsSelected == true;
+            AlwaysOnTopSwitch.EyeFollowGlobal = isSettingsTabVisible;
+        }
+
+        private void OnPreviewVisibilityChanged(object sender, bool isVisible)
+        {
+            if (AlwaysOnTopSwitch == null) return;
+
+            void Apply()
+            {
+                bool shouldSuspend = isVisible && _revitMajorVersion >= 2025;
+                AlwaysOnTopSwitch.SetTrackingSuspended(shouldSuspend);
+            }
+
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.BeginInvoke((Action)Apply);
+            }
+            else
+            {
+                Apply();
+            }
         }
 
         #endregion

--- a/BIMaestro/commands/Dossier famille/orbit 3D/FamilyPreviewBridge.cs
+++ b/BIMaestro/commands/Dossier famille/orbit 3D/FamilyPreviewBridge.cs
@@ -29,6 +29,8 @@ namespace Famille.Orbit3D
         private static int _revitMajor;                 // cache version
         private static IntPtr _ownerHwnd = IntPtr.Zero; // owner Revit
 
+        public static event EventHandler<bool> PreviewVisibilityChanged;
+
         // ------------- Public API -------------
 
         public static void ShowPreview(UIApplication uiapp, string familyPath)
@@ -50,6 +52,7 @@ namespace Famille.Orbit3D
                     _host.Window.ClearScene(); // nettoie l'ancien contenu si besoin
                     _host.Window.ShowBusy(true, "Chargement de la famille…");
                     if (!_host.Window.IsVisible) _host.Window.Show();
+                    RaisePreviewVisibilityChanged(_host.Window.IsVisible);
                     _host.Window.Activate();
                 }
                 catch { /* ignore */ }
@@ -135,6 +138,12 @@ namespace Famille.Orbit3D
                 _host = CreatePreviewWindowOnRevitThread(_ownerHwnd);
         }
 
+        private static void RaisePreviewVisibilityChanged(bool isVisible)
+        {
+            try { PreviewVisibilityChanged?.Invoke(null, isVisible); }
+            catch { }
+        }
+
         private static PreviewHost CreatePreviewWindowOnSta(IntPtr ownerHwnd)
         {
             var host = new PreviewHost { IsStaThreadWindow = true };
@@ -156,7 +165,10 @@ namespace Famille.Orbit3D
                     host.Window = win;
                     host.Dispatcher = win.Dispatcher;
 
+                    win.IsVisibleChanged += (s, e) => RaisePreviewVisibilityChanged(win.IsVisible);
+
                     win.Show();               // modeless
+                    RaisePreviewVisibilityChanged(win.IsVisible);
                     ready.Set();              // signal prêt
                     Dispatcher.Run();         // boucle WPF du thread
                 }
@@ -182,6 +194,8 @@ namespace Famille.Orbit3D
                 var win = new Family3DPreviewWindow();
                 new WindowInteropHelper(win) { Owner = ownerHwnd };
                 win.Show();
+                win.IsVisibleChanged += (s, e) => RaisePreviewVisibilityChanged(win.IsVisible);
+                RaisePreviewVisibilityChanged(win.IsVisible);
                 // flush visuel pour que "Chargement…" apparaisse même si Revit va mouliner ensuite
                 win.Dispatcher.Invoke(DispatcherPriority.Render, new Action(() => { }));
                 host.Window = win;


### PR DESCRIPTION
## Summary
- expose a preview visibility event from the 3D preview bridge so other UI can react when the window shows or hides
- allow the GhostSwitch control to suspend its pointer tracking hooks while the preview is open
- disable the ghost tracking when the 3D preview is visible on Revit 2025 so the preview window remains responsive

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68edfce37290832eb3770bfaa285102e