### PR TITLE
Improve ConnectPipesCommand obstacle handling

### DIFF
--- a/BIMaestro/commands/réseau auto entre canalisation/ConnectPipesCommand.cs
+++ b/BIMaestro/commands/réseau auto entre canalisation/ConnectPipesCommand.cs
@@ -97,36 +97,69 @@ namespace Modification
                 double expandGlobalMm = Math.Max(1600, XY_MARGINS_MM.Max() + corridorMm + 3000);
                 var bboxGlobal = MakeOutline(start, end, expandGlobalMm);
                 var obstaclesRaw = CollectObstacleAabbsInOutline(doc, bboxGlobal, new[] { p1.Id, p2.Id });
+                var obstaclesForSnap = obstaclesRaw;
+
+                var stepsFast = ComputeMarginSteps(gridFastMm);
+                var stepsFine = ComputeMarginSteps(gridFineMm);
 
                 // ---- 4) Routes candidates ----
                 var routes = new List<RouteCandidate>();
 
-                var aFast = AStarMulti(start, end, obstaclesRaw, gridFastMm, zStepMm, clearMm, exemptMm, stepsFast, 1.0);
-                if (aFast != null)
+                var fastRoute = TryComputeAStarRoute(
+                    start,
+                    end,
+                    obstaclesRaw,
+                    obstaclesForSnap,
+                    gridFastMm,
+                    stepsFast,
+                    heuristicBias: 1.0,
+                    zStepMm,
+                    clearMm,
+                    clearFt,
+                    snapTolMm,
+                    jogTolMm,
+                    minSegMm,
+                    exemptMm);
+                if (fastRoute != null)
                 {
-                    aFast.Points = PostProcess(aFast.Points, obstaclesRaw, clearMm, snapTolMm, jogTolMm, minSegMm);
-                    aFast.Points = ForceEndpoints(aFast.Points, start, end);
-                    routes.Add(aFast);
+                    fastRoute.Label = "Recherche rapide (A*)";
+                    routes.Add(fastRoute);
                 }
 
-                var aFine = AStarMulti(start, end, obstaclesRaw, gridFineMm, zStepMm, clearMm, exemptMm, stepsFine, 1.06);
-                if (aFine != null)
+                var fineRoute = TryComputeAStarRoute(
+                    start,
+                    end,
+                    obstaclesRaw,
+                    obstaclesForSnap,
+                    gridFineMm,
+                    stepsFine,
+                    heuristicBias: 1.06,
+                    zStepMm,
+                    clearMm,
+                    clearFt,
+                    snapTolMm,
+                    jogTolMm,
+                    minSegMm,
+                    exemptMm);
+                if (fineRoute != null)
                 {
-                    aFine.Points = PostProcess(aFine.Points, obstaclesRaw, clearMm, snapTolMm, jogTolMm, minSegMm);
-                    aFine.Points = ForceEndpoints(aFine.Points, start, end);
-                    routes.Add(aFine);
+                    fineRoute.Label = "Recherche fine (A*)";
+                    routes.Add(fineRoute);
                 }
 
                 var detours = BuildDetoursAroundBlockingWalls(start, end, obstaclesRaw, clearMm, detourPadMm);
-                foreach (var d in detours)
+                foreach (var detour in detours)
                 {
-                    var fixedPts = ForceEndpoints(d.Points, start, end);
+                    var fixedPts = ForceEndpoints(detour.Points, start, end);
                     var processed = PostProcess(fixedPts, obstaclesRaw, obstaclesForSnap, clearMm, snapTolMm, jogTolMm, minSegMm);
                     if (processed != null && processed.Count > 1 && IsPolylineClear(processed, obstaclesRaw, clearFt))
                     {
-                        Label  = "Contournement direct",
-                        Points = PostProcess(fixedPts, obstaclesRaw, clearMm, snapTolMm, jogTolMm, minSegMm)
-                    });
+                        routes.Add(new RouteCandidate
+                        {
+                            Label = detour.Label,
+                            Points = processed
+                        });
+                    }
                 }
 
                 if (routes.Count == 0)
@@ -825,20 +858,24 @@ namespace Modification
                 .WherePasses(filter)
                 .WhereElementIsNotElementType();
 
-            if (OBSTACLE_CATEGORIES.Length > 0)
-                collector = collector.WherePasses(new ElementMulticategoryFilter(OBSTACLE_CATEGORIES));
-
             HashSet<ElementId> ignore = null;
             if (ignoreIds != null)
                 ignore = new HashSet<ElementId>(ignoreIds.Where(id => id != null && id != ElementId.InvalidElementId));
 
+            var allowedCategories = new HashSet<int>(OBSTACLE_CATEGORIES.Select(c => (int)c));
             var list = new List<BoundingBoxXYZ>();
+
             foreach (var element in collector)
             {
-                if (ignore != null && ignore.Contains(element.Id)) continue;
+                if (ignore != null && ignore.Contains(element.Id))
+                    continue;
+
+                if (!IsPhysicalObstacle(element, allowedCategories))
+                    continue;
 
                 var bb = element.get_BoundingBox(null);
-                if (bb == null) continue;
+                if (bb == null)
+                    continue;
 
                 // Copie défensive + léger tampon pour éviter les collisions tangentes
                 double pad = MmToFt(10);
@@ -851,13 +888,79 @@ namespace Modification
                 list.Add(clone);
             }
 
-            foreach (var cat in categories)
-                AppendCategory(cat);
-
-            if (list.Count == 0)
-                AppendCategory(BuiltInCategory.OST_Walls);
-
             return list;
+        }
+
+        private static int[] ComputeMarginSteps(double gridStepMm)
+        {
+            if (gridStepMm <= 0)
+                return new[] { 1 };
+
+            return XY_MARGINS_MM
+                .Select(mm => Math.Max(1, (int)Math.Round(mm / gridStepMm)))
+                .Distinct()
+                .OrderBy(v => v)
+                .ToArray();
+        }
+
+        private static bool IsPhysicalObstacle(Element element, HashSet<int> allowedCategories)
+        {
+            if (element == null)
+                return false;
+
+            var category = element.Category;
+            if (category == null || category.CategoryType != CategoryType.Model)
+                return false;
+
+            int catId = category.Id.IntegerValue;
+            if (allowedCategories.Contains(catId))
+                return true;
+
+            if (!HasSolidGeometry(element))
+                return false;
+
+            allowedCategories.Add(catId);
+            return true;
+        }
+
+        private static bool HasSolidGeometry(Element element)
+        {
+            try
+            {
+                var options = new Options
+                {
+                    ComputeReferences = false,
+                    IncludeNonVisibleObjects = false,
+                    DetailLevel = ViewDetailLevel.Fine
+                };
+
+                var geom = element.get_Geometry(options);
+                if (geom == null)
+                    return false;
+
+                foreach (var obj in geom)
+                {
+                    if (obj is Solid solid && solid.Volume > 1e-6)
+                        return true;
+
+                    if (obj is GeometryInstance inst)
+                    {
+                        var instGeom = inst.GetInstanceGeometry();
+                        if (instGeom == null)
+                            continue;
+
+                        foreach (var instObj in instGeom)
+                            if (instObj is Solid instSolid && instSolid.Volume > 1e-6)
+                                return true;
+                    }
+                }
+            }
+            catch
+            {
+                // En cas de géométrie inaccessible on considère que l'élément n'est pas bloquant
+            }
+
+            return false;
         }
 
         private static RouteCandidate TryComputeAStarRoute(
@@ -1114,14 +1217,21 @@ namespace Modification
 
         // ======================== LISSAGE / SNAP / CLEAR ========================
 
-        private static List<XYZ> PostProcess(List<XYZ> pts, List<BoundingBoxXYZ> obstaclesRaw, double clearMm, double snapTolMm, double jogTolMm, double minSegMm)
+        private static List<XYZ> PostProcess(
+            List<XYZ> pts,
+            List<BoundingBoxXYZ> obstaclesRaw,
+            List<BoundingBoxXYZ> obstaclesForSnap,
+            double clearMm,
+            double snapTolMm,
+            double jogTolMm,
+            double minSegMm)
         {
             if (pts == null || pts.Count == 0) return pts;
 
             double clearFt = MmToFt(clearMm);
             var p = SmoothRectilinear(pts, obstaclesRaw, clearFt);
             p = AxisAlignAndFlatten(p); // pas de mini-pentes
-            p = SnapPolylineToWallOffsets(p, obstaclesRaw, clearMm, snapTolMm);
+            p = SnapPolylineToObstacleOffsets(p, obstaclesForSnap ?? obstaclesRaw, clearMm, snapTolMm);
             p = CollapseAdjacentCorners(p, obstaclesRaw, clearFt, jogTolMm);
             p = CollapseZigZagDoglegs(p, obstaclesRaw, clearFt, doglegTolMm: Math.Max(120, jogTolMm)); // supprime les “Z”
 
@@ -1234,7 +1344,7 @@ namespace Modification
             return result;
         }
 
-        private static List<XYZ> SnapPolylineToWallOffsets(List<XYZ> pts, List<BoundingBoxXYZ> obstaclesRaw, double clearMm, double tolMm)
+        private static List<XYZ> SnapPolylineToObstacleOffsets(List<XYZ> pts, List<BoundingBoxXYZ> obstaclesRaw, double clearMm, double tolMm)
         {
             if (pts.Count < 3) return pts;
             double clear = MmToFt(clearMm), tol = MmToFt(tolMm);


### PR DESCRIPTION
## Summary
- include physical model obstacles beyond walls when building the avoidance map
- reuse a shared A* routing helper and margin computation to generate candidate paths
- generalise snapping/post-processing so routes hug whichever elements are blocking the corridor

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690235ed4a98832e9509a6a65b7902dc