### PR TITLE
Enhance family browser UI for documentation and collections

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -115,6 +115,27 @@
                                VerticalAlignment="Center"
                                Style="{StaticResource ImageStyle}"/>
                     </Border>
+                    <Button Content="DOC"
+                            Width="34" Height="20" FontSize="10" Padding="0"
+                            HorizontalAlignment="Left" VerticalAlignment="Top" Margin="4"
+                            Click="DocumentationBadge_Click"
+                            ToolTip="Afficher la documentation"
+                            Background="#FF2A3F6A"
+                            Foreground="White"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            FocusVisualStyle="{x:Null}">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding DocumentationAvailable}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
                     <Button Content="3D"
                             Width="28" Height="20" FontSize="10" Padding="0"
                             HorizontalAlignment="Right" VerticalAlignment="Top" Margin="4"
@@ -224,6 +245,27 @@
 
                         <DockPanel Grid.Row="0" LastChildFill="True">
                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Content="DOC"
+                                        Width="38" Height="22" FontSize="10" Padding="0"
+                                        Margin="0,0,8,0"
+                                        Click="DocumentationBadge_Click"
+                                        ToolTip="Afficher la documentation"
+                                        Background="#FF2A3F6A"
+                                        Foreground="White"
+                                        BorderBrush="Transparent"
+                                        BorderThickness="0"
+                                        FocusVisualStyle="{x:Null}">
+                                    <Button.Style>
+                                        <Style TargetType="Button">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding DocumentationAvailable}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
                                 <Button Content="3D"
                                         Width="32" Height="22" FontSize="10" Padding="0"
                                         Margin="0,0,8,0"
@@ -609,6 +651,33 @@
 
                         <DockPanel Grid.Row="3">
                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                                <Button x:Name="DateSortButton"
+                                        Content="Date de MAJ"
+                                        Margin="0,0,12,0"
+                                        Click="DateSortButton_Click"
+                                        Cursor="Hand"
+                                        Padding="10,4"
+                                        ToolTip="Trier les familles par date de mise à jour">
+                                    <Button.Style>
+                                        <Style TargetType="Button">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Setter Property="Background" Value="#FFE9EEF6"/>
+                                            <Setter Property="BorderBrush" Value="#FFC9D7F5"/>
+                                            <Setter Property="BorderThickness" Value="1"/>
+                                            <Setter Property="FontWeight" Value="Normal"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsChecked, ElementName=DetailedViewCheckBox}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsDateSortActive}" Value="True">
+                                                    <Setter Property="Background" Value="#FFD9E8FF"/>
+                                                    <Setter Property="BorderBrush" Value="#FF8AB4F8"/>
+                                                    <Setter Property="FontWeight" Value="SemiBold"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
                                 <CheckBox x:Name="DetailedViewCheckBox"
                                           Content="Vue détaillée"
                                           Margin="0,0,20,0"
@@ -651,6 +720,17 @@
                             <Button Content="Charger la collection"
                                     Width="160"
                                     Click="CollectionLoad_Click"/>
+                            <Button Content="⋯"
+                                    Width="36" Height="28" Margin="6,0,0,0"
+                                    Click="CollectionOptionsButton_Click"
+                                    ToolTip="Plus d'options">
+                                <Button.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Partager…" Click="CollectionShare_Click"/>
+                                        <MenuItem Header="Télécharger…" Click="CollectionDownload_Click"/>
+                                    </ContextMenu>
+                                </Button.ContextMenu>
+                            </Button>
                         </StackPanel>
                     </DockPanel>
 

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -53,6 +53,7 @@ namespace Famille
         private string _activeCategoryFilter;
         private string _activeVersionFilter;
         private bool _sizeSortDescending;
+        private bool _dateSortDescending;
         private bool _isResorting;
 
         // ===== Données UI =====
@@ -86,6 +87,7 @@ namespace Famille
         }
 
         public bool IsSizeSortActive => _sizeSortDescending;
+        public bool IsDateSortActive => _dateSortDescending;
 
         public event PropertyChangedEventHandler PropertyChanged;
         private void NotifyPropertyChanged(string propertyName)
@@ -421,6 +423,11 @@ namespace Famille
             ToggleSizeSorting();
         }
 
+        private void DateSortButton_Click(object sender, RoutedEventArgs e)
+        {
+            ToggleDateSorting();
+        }
+
         private void SetCategoryFilter(string category)
         {
             string normalized = string.IsNullOrWhiteSpace(category) ? null : category.Trim();
@@ -456,6 +463,16 @@ namespace Famille
             ApplyFilters();
         }
 
+        private void ToggleDateSorting()
+        {
+            if (!detailedViewMode && !_dateSortDescending)
+                return;
+
+            _dateSortDescending = !_dateSortDescending;
+            NotifyPropertyChanged(nameof(IsDateSortActive));
+            ApplyFilters();
+        }
+
         private void ResetInteractiveFilters()
         {
             ActiveCategoryFilter = null;
@@ -465,6 +482,12 @@ namespace Famille
             {
                 _sizeSortDescending = false;
                 NotifyPropertyChanged(nameof(IsSizeSortActive));
+            }
+
+            if (_dateSortDescending)
+            {
+                _dateSortDescending = false;
+                NotifyPropertyChanged(nameof(IsDateSortActive));
             }
         }
         private List<FamilyItem> ApplyInteractiveSorting(List<FamilyItem> source)
@@ -481,8 +504,9 @@ namespace Famille
             bool hasCategory = !string.IsNullOrEmpty(categoryFilter);
             bool hasVersion = !string.IsNullOrEmpty(versionFilter);
             bool hasSizeSort = _sizeSortDescending;
+            bool hasDateSort = _dateSortDescending;
 
-            if (!hasCategory && !hasVersion && !hasSizeSort)
+            if (!hasCategory && !hasVersion && !hasSizeSort && !hasDateSort)
                 return result;
 
             bool CategoryMatches(FamilyItem item)
@@ -517,6 +541,15 @@ namespace Famille
                     int verCmp = VersionMatches(b).CompareTo(VersionMatches(a));
                     if (verCmp != 0)
                         return verCmp;
+                }
+
+                if (hasDateSort)
+                {
+                    var aDate = a?.LastUpdatedUtc ?? DateTime.MinValue;
+                    var bDate = b?.LastUpdatedUtc ?? DateTime.MinValue;
+                    int dateCmp = bDate.CompareTo(aDate);
+                    if (dateCmp != 0)
+                        return dateCmp;
                 }
 
                 if (hasSizeSort)
@@ -653,6 +686,7 @@ namespace Famille
                 var items = hits.Select(e =>
                 {
                     var size = TryGetFileSize(e.Path);
+                    var lastUpdated = TryGetLastWriteTimeUtc(e.Path);
                     return new FamilyItem
                     {
                         Name = e.Name,
@@ -660,7 +694,10 @@ namespace Famille
                         Category = e.Category,
                         NormalizedName = e.NormalizedName,
                         FileSizeBytes = size,
-                        FileSizeText = FormatFileSize(size)
+                        FileSizeText = FormatFileSize(size),
+                        LastUpdatedUtc = lastUpdated,
+                        LastUpdatedText = FormatLastUpdated(lastUpdated),
+                        DocumentationAvailable = HasDocumentationOnDisk(e.Path)
                     };
                 }).ToList();
 
@@ -749,6 +786,24 @@ namespace Famille
             if ((sender as MenuItem)?.DataContext is not FamilyItem fam)
                 return;
 
+            HandleDocumentationRequest(fam);
+        }
+
+        private void DocumentationBadge_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+
+            if ((sender as FrameworkElement)?.DataContext is not FamilyItem fam)
+                return;
+
+            HandleDocumentationRequest(fam);
+        }
+
+        private void HandleDocumentationRequest(FamilyItem fam)
+        {
+            if (fam == null)
+                return;
+
             EnsureDocumentationLoaded(fam);
 
             if (!fam.HasDocumentation)
@@ -799,6 +854,8 @@ namespace Famille
             {
                 fam.DocumentationLinks.Add(link.Clone());
             }
+
+            fam.DocumentationAvailable = docs?.Count > 0;
         }
 
         private List<FamilyDocumentLink> LoadDocumentationFromDisk(string familyPath)
@@ -904,6 +961,8 @@ namespace Famille
 
             SortDocumentationLinks(fam);
 
+            fam.DocumentationAvailable = fam.DocumentationLinks.Count > 0;
+
             if (!PersistDocumentation(fam))
             {
                 EnsureDocumentationLoaded(fam);
@@ -964,6 +1023,7 @@ namespace Famille
                     File.WriteAllText(docFile, json, Encoding.UTF8);
                 }
 
+                fam.DocumentationAvailable = snapshot.Count > 0;
                 return true;
             }
             catch (Exception ex)
@@ -1277,6 +1337,146 @@ namespace Famille
             FamilyBrowserCommand.LoadCollectionEventInstance.Raise();
         }
 
+        private void CollectionOptionsButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.ContextMenu == null)
+                return;
+
+            btn.ContextMenu.PlacementTarget = btn;
+            btn.ContextMenu.IsOpen = true;
+        }
+
+        private void CollectionShare_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedCollection == null || _selectedCollection.Paths.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "Sélectionne une collection contenant au moins une famille avant de partager.",
+                    "Partager la collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Title = "Exporter la collection",
+                Filter = "Collection BIMaestro (*.json)|*.json|Tous les fichiers (*.*)|*.*",
+                FileName = _selectedCollection.Name + ".json"
+            };
+
+            if (dialog.ShowDialog(this) != true)
+                return;
+
+            try
+            {
+                var export = new
+                {
+                    _selectedCollection.Name,
+                    _selectedCollection.Id,
+                    Paths = _selectedCollection.Paths.ToList(),
+                    ExportedAtUtc = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)
+                };
+
+                var json = JsonConvert.SerializeObject(export, Formatting.Indented);
+                File.WriteAllText(dialog.FileName, json, Encoding.UTF8);
+
+                MessageBox.Show(this,
+                    "La collection a été exportée avec succès.",
+                    "Partager la collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this,
+                    "Impossible d'exporter la collection :\n" + ex.Message,
+                    "Partager la collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        private void CollectionDownload_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedCollection == null || _selectedCollection.Paths.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "Sélectionne une collection contenant au moins une famille avant de télécharger.",
+                    "Télécharger la collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            using var folderDialog = new WinForms.FolderBrowserDialog
+            {
+                Description = "Sélectionner le dossier de destination pour la collection"
+            };
+
+            if (folderDialog.ShowDialog() != WinForms.DialogResult.OK || string.IsNullOrWhiteSpace(folderDialog.SelectedPath))
+                return;
+
+            Directory.CreateDirectory(folderDialog.SelectedPath);
+
+            int copied = 0;
+            var errors = new List<string>();
+
+            foreach (var path in _selectedCollection.Paths.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                if (!File.Exists(path))
+                {
+                    errors.Add("Introuvable : " + path);
+                    continue;
+                }
+
+                try
+                {
+                    var fileName = System.IO.Path.GetFileName(path);
+                    var target = System.IO.Path.Combine(folderDialog.SelectedPath, fileName);
+                    File.Copy(path, target, overwrite: true);
+                    copied++;
+                }
+                catch (Exception ex)
+                {
+                    errors.Add(System.IO.Path.GetFileName(path) + " : " + ex.Message);
+                }
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
+                "{0} fichier(s) copié(s) dans {1}.",
+                copied,
+                folderDialog.SelectedPath));
+
+            if (errors.Count > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Certains fichiers n'ont pas pu être copiés :");
+
+                foreach (var err in errors.Take(5))
+                {
+                    builder.AppendLine("- " + err);
+                }
+
+                if (errors.Count > 5)
+                {
+                    builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
+                        "... ({0} erreur(s) supplémentaire(s))",
+                        errors.Count - 5));
+                }
+            }
+
+            MessageBox.Show(this,
+                builder.ToString(),
+                "Télécharger la collection",
+                MessageBoxButton.OK,
+                errors.Count > 0 ? MessageBoxImage.Warning : MessageBoxImage.Information);
+        }
+
         #endregion
 
         #region Vignettes (catalogue -> cache -> Shell -> placeholder)
@@ -1436,24 +1636,19 @@ namespace Famille
 
                     if (meta.UpdatedUtc.HasValue)
                     {
-                        try
-                        {
-                            var local = TimeZoneInfo.ConvertTimeFromUtc(meta.UpdatedUtc.Value, TimeZoneInfo.Local);
-                            fam.LastUpdatedText = local.ToString("g", CultureInfo.CurrentCulture);
-                        }
-                        catch
-                        {
-                            fam.LastUpdatedText = meta.UpdatedUtc.Value.ToString("u", CultureInfo.InvariantCulture);
-                        }
+                        fam.LastUpdatedUtc = meta.UpdatedUtc.Value;
                     }
                     else
                     {
-                        fam.LastUpdatedText = null;
+                        fam.LastUpdatedUtc = TryGetLastWriteTimeUtc(fam.Path);
                     }
+
+                    fam.LastUpdatedText = FormatLastUpdated(fam.LastUpdatedUtc);
                 }
                 else
                 {
-                    fam.LastUpdatedText = null;
+                    fam.LastUpdatedUtc = TryGetLastWriteTimeUtc(fam.Path);
+                    fam.LastUpdatedText = FormatLastUpdated(fam.LastUpdatedUtc);
                     fam.RevitSavedVersion = null;
                     if (string.IsNullOrWhiteSpace(fam.Category))
                         fam.Category = null;
@@ -1461,6 +1656,7 @@ namespace Famille
 
                 if (!_isResorting &&
                     (_sizeSortDescending ||
+                     _dateSortDescending ||
                      !string.IsNullOrEmpty(ActiveCategoryFilter) ||
                      !string.IsNullOrEmpty(ActiveVersionFilter)))
                 {
@@ -1493,6 +1689,22 @@ namespace Famille
                 "{0} octet{1}",
                 bytes.Value,
                 bytes.Value > 1 ? "s" : string.Empty);
+        }
+
+        private static string FormatLastUpdated(DateTime? utc)
+        {
+            if (!utc.HasValue)
+                return null;
+
+            try
+            {
+                var local = TimeZoneInfo.ConvertTimeFromUtc(utc.Value, TimeZoneInfo.Local);
+                return local.ToString("g", CultureInfo.CurrentCulture);
+            }
+            catch
+            {
+                return utc.Value.ToString("u", CultureInfo.InvariantCulture);
+            }
         }
 
 
@@ -1860,7 +2072,19 @@ namespace Famille
         private void DetailedViewCheckBox_Changed(object sender, RoutedEventArgs e)
         {
             detailedViewMode = DetailedViewCheckBox?.IsChecked == true;
+
+            if (!detailedViewMode && _dateSortDescending)
+            {
+                _dateSortDescending = false;
+                NotifyPropertyChanged(nameof(IsDateSortActive));
+            }
+
             UpdateFamilyListViewMode();
+
+            if (_currentResult?.Count > 0)
+            {
+                ApplyFilters();
+            }
         }
 
         private void UpdateFamilyListViewMode()
@@ -2171,10 +2395,27 @@ namespace Famille
             }
         }
 
+        private DateTime? TryGetLastWriteTimeUtc(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                return info.Exists ? info.LastWriteTimeUtc : (DateTime?)null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private bool HasDocumentationOnDisk(string path)
+            => !string.IsNullOrWhiteSpace(path) && File.Exists(GetDocumentationFilePath(path));
+
         private FamilyItem CreateFamilyItemFromPath(string path)
         {
             var name = System.IO.Path.GetFileNameWithoutExtension(path);
             var size = TryGetFileSize(path);
+            var lastUpdatedUtc = TryGetLastWriteTimeUtc(path);
             return new FamilyItem
             {
                 Name = name,
@@ -2182,7 +2423,10 @@ namespace Famille
                 Icon = null,
                 NormalizedName = StripDiacritics(name).ToLowerInvariant(),
                 FileSizeBytes = size,
-                FileSizeText = FormatFileSize(size)
+                FileSizeText = FormatFileSize(size),
+                LastUpdatedUtc = lastUpdatedUtc,
+                LastUpdatedText = FormatLastUpdated(lastUpdatedUtc),
+                DocumentationAvailable = HasDocumentationOnDisk(path)
             };
         }
 
@@ -2257,6 +2501,20 @@ namespace Famille
             set { if (_fileSizeBytes != value) { _fileSizeBytes = value; OnPropertyChanged(nameof(FileSizeBytes)); } }
         }
 
+        private DateTime? _lastUpdatedUtc;
+        public DateTime? LastUpdatedUtc
+        {
+            get => _lastUpdatedUtc;
+            set { if (_lastUpdatedUtc != value) { _lastUpdatedUtc = value; OnPropertyChanged(nameof(LastUpdatedUtc)); } }
+        }
+
+        private bool _documentationAvailable;
+        public bool DocumentationAvailable
+        {
+            get => _documentationAvailable;
+            set { if (_documentationAvailable != value) { _documentationAvailable = value; OnPropertyChanged(nameof(DocumentationAvailable)); } }
+        }
+
         public ObservableCollection<FamilyDocumentLink> DocumentationLinks { get; }
 
         public bool HasDocumentation => DocumentationLinks?.Count > 0;
@@ -2265,6 +2523,21 @@ namespace Famille
         {
             OnPropertyChanged(nameof(DocumentationLinks));
             OnPropertyChanged(nameof(HasDocumentation));
+
+            bool hasDocs = DocumentationLinks?.Count > 0;
+            if (!hasDocs && !string.IsNullOrWhiteSpace(Path))
+            {
+                try
+                {
+                    hasDocs = File.Exists(Path + ".docs.json");
+                }
+                catch
+                {
+                    hasDocs = false;
+                }
+            }
+
+            DocumentationAvailable = hasDocs;
         }
 
 


### PR DESCRIPTION
## Summary
- add DOC badges to family tiles and detailed rows to open associated documentation directly
- track documentation availability and last updated dates on family items and expose a Date de MAJ sort toggle for detailed view
- extend the collections toolbar with an options menu to export or download the current selection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6902393b8610832ea217c94c6fb67291