### PR TITLE
Refine documentation badge and improve collection import

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -71,6 +71,60 @@
             </Setter>
         </Style>
 
+        <Style x:Key="DocumentationBadgeStyle" TargetType="Button">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="ToolTip" Value="Ouvrir la documentation"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="BadgeBorder"
+                                Background="#FF21527A"
+                                BorderBrush="#FF9AC5FF"
+                                BorderThickness="1"
+                                CornerRadius="10"
+                                Padding="6,3"
+                                SnapsToDevicePixels="True">
+                            <Border.Effect>
+                                <DropShadowEffect ShadowDepth="1" BlurRadius="5" Opacity="0.4"/>
+                            </Border.Effect>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <Path Data="M1,1 L6.3,1 L9,3.7 L9,11 L1,11 Z"
+                                      Fill="White"
+                                      Stretch="Uniform"
+                                      Width="9"
+                                      Height="10"
+                                      Margin="0,0,4,0"/>
+                                <TextBlock Text="DOC"
+                                           FontSize="11"
+                                           FontWeight="SemiBold"
+                                           Foreground="White"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="BadgeBorder" Property="Background" Value="#FF2D7DDB"/>
+                                <Setter TargetName="BadgeBorder" Property="BorderBrush" Value="#FFE6F0FF"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="BadgeBorder" Property="Background" Value="#FF1B4F8C"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="BadgeBorder" Property="Opacity" Value="0.6"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding DocumentationAvailable}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
         <!-- Vignette famille (onglet Dossiers) -->
         <DataTemplate x:Key="FamilyItemTemplate" DataType="{x:Type local:FamilyItem}">
             <Border Margin="5" Width="200"
@@ -107,14 +161,21 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <Border Background="{DynamicResource ImageBackground}" Padding="3" Grid.Row="0">
-                        <Image Source="{Binding Icon}"
-                               Width="180" Height="180"
-                               Stretch="UniformToFill"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               Style="{StaticResource ImageStyle}"/>
-                    </Border>
+                    <Grid Grid.Row="0">
+                        <Border Background="{DynamicResource ImageBackground}" Padding="3">
+                            <Image Source="{Binding Icon}"
+                                   Width="180" Height="180"
+                                   Stretch="UniformToFill"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Style="{StaticResource ImageStyle}"/>
+                        </Border>
+                        <Button Style="{StaticResource DocumentationBadgeStyle}"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Margin="6"
+                                Click="DocumentationBadge_Click"/>
+                    </Grid>
                     <Button Content="3D"
                             Width="28" Height="20" FontSize="10" Padding="0"
                             HorizontalAlignment="Right" VerticalAlignment="Top" Margin="4"
@@ -201,17 +262,22 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Background="{DynamicResource ImageBackground}"
-                            Padding="3"
-                            Grid.Column="0"
-                            HorizontalAlignment="Left">
-                        <Image Source="{Binding Icon}"
-                               Width="200" Height="200"
-                               Stretch="Uniform"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               Style="{StaticResource ImageStyle}"/>
-                    </Border>
+                    <Grid Grid.Column="0" HorizontalAlignment="Left">
+                        <Border Background="{DynamicResource ImageBackground}"
+                                Padding="3">
+                            <Image Source="{Binding Icon}"
+                                   Width="200" Height="200"
+                                   Stretch="Uniform"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Style="{StaticResource ImageStyle}"/>
+                        </Border>
+                        <Button Style="{StaticResource DocumentationBadgeStyle}"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Margin="6"
+                                Click="DocumentationBadge_Click"/>
+                    </Grid>
 
                     <Grid Grid.Column="1" Margin="20,0,10,0">
                         <Grid.RowDefinitions>
@@ -449,14 +515,21 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <Border Background="{DynamicResource ImageBackground}" Padding="3" Grid.Row="0">
-                        <Image Source="{Binding Icon}"
-                               Width="180" Height="180"
-                               Stretch="UniformToFill"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               Style="{StaticResource ImageStyle}"/>
-                    </Border>
+                    <Grid Grid.Row="0">
+                        <Border Background="{DynamicResource ImageBackground}" Padding="3">
+                            <Image Source="{Binding Icon}"
+                                   Width="180" Height="180"
+                                   Stretch="UniformToFill"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Style="{StaticResource ImageStyle}"/>
+                        </Border>
+                        <Button Style="{StaticResource DocumentationBadgeStyle}"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Margin="6"
+                                Click="DocumentationBadge_Click"/>
+                    </Grid>
 
                     <Grid Grid.Row="1">
                         <Grid.ColumnDefinitions>
@@ -609,6 +682,26 @@
 
                         <DockPanel Grid.Row="3">
                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                                <Button x:Name="DateSortButton"
+                                        Content="Date de MAJ"
+                                        Click="DateSortButton_Click">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource PillButtonStyle}">
+                                            <Setter Property="Margin" Value="0,0,12,0"/>
+                                            <Setter Property="Padding" Value="12,4"/>
+                                            <Setter Property="Background" Value="#FFF2F5FC"/>
+                                            <Setter Property="BorderBrush" Value="#FFDCE6FA"/>
+                                            <Setter Property="Foreground" Value="#FF2A3F6A"/>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=IsDateSortActive}" Value="True">
+                                                <Setter Property="Background" Value="#FFE0F2FF"/>
+                                                <Setter Property="BorderBrush" Value="#FF5AA0FF"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsChecked, ElementName=DetailedViewCheckBox}" Value="False">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
                                 <CheckBox x:Name="DetailedViewCheckBox"
                                           Content="Vue détaillée"
                                           Margin="0,0,20,0"
@@ -648,6 +741,23 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                            <Button x:Name="CollectionActionsButton"
+                                    Content="Partager"
+                                    Width="120"
+                                    Margin="0,0,10,0"
+                                    Click="CollectionActionsButton_Click">
+                                <Button.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Importer une collection…"
+                                                  Click="CollectionImportMenuItem_Click"/>
+                                        <Separator/>
+                                        <MenuItem Header="Partager la collection…"
+                                                  Click="CollectionShareMenuItem_Click"/>
+                                        <MenuItem Header="Télécharger les familles…"
+                                                  Click="CollectionDownloadMenuItem_Click"/>
+                                    </ContextMenu>
+                                </Button.ContextMenu>
+                            </Button>
                             <Button Content="Charger la collection"
                                     Width="160"
                                     Click="CollectionLoad_Click"/>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -53,6 +54,7 @@ namespace Famille
         private string _activeCategoryFilter;
         private string _activeVersionFilter;
         private bool _sizeSortDescending;
+        private bool _dateSortDescending;
         private bool _isResorting;
 
         // ===== Données UI =====
@@ -86,6 +88,7 @@ namespace Famille
         }
 
         public bool IsSizeSortActive => _sizeSortDescending;
+        public bool IsDateSortActive => _dateSortDescending;
 
         public event PropertyChangedEventHandler PropertyChanged;
         private void NotifyPropertyChanged(string propertyName)
@@ -421,6 +424,14 @@ namespace Famille
             ToggleSizeSorting();
         }
 
+        private void DateSortButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (DetailedViewCheckBox?.IsChecked != true)
+                return;
+
+            ToggleDateSorting();
+        }
+
         private void SetCategoryFilter(string category)
         {
             string normalized = string.IsNullOrWhiteSpace(category) ? null : category.Trim();
@@ -456,6 +467,13 @@ namespace Famille
             ApplyFilters();
         }
 
+        private void ToggleDateSorting()
+        {
+            _dateSortDescending = !_dateSortDescending;
+            NotifyPropertyChanged(nameof(IsDateSortActive));
+            ApplyFilters();
+        }
+
         private void ResetInteractiveFilters()
         {
             ActiveCategoryFilter = null;
@@ -465,6 +483,12 @@ namespace Famille
             {
                 _sizeSortDescending = false;
                 NotifyPropertyChanged(nameof(IsSizeSortActive));
+            }
+
+            if (_dateSortDescending)
+            {
+                _dateSortDescending = false;
+                NotifyPropertyChanged(nameof(IsDateSortActive));
             }
         }
         private List<FamilyItem> ApplyInteractiveSorting(List<FamilyItem> source)
@@ -481,8 +505,9 @@ namespace Famille
             bool hasCategory = !string.IsNullOrEmpty(categoryFilter);
             bool hasVersion = !string.IsNullOrEmpty(versionFilter);
             bool hasSizeSort = _sizeSortDescending;
+            bool hasDateSort = _dateSortDescending;
 
-            if (!hasCategory && !hasVersion && !hasSizeSort)
+            if (!hasCategory && !hasVersion && !hasSizeSort && !hasDateSort)
                 return result;
 
             bool CategoryMatches(FamilyItem item)
@@ -517,6 +542,15 @@ namespace Famille
                     int verCmp = VersionMatches(b).CompareTo(VersionMatches(a));
                     if (verCmp != 0)
                         return verCmp;
+                }
+
+                if (hasDateSort)
+                {
+                    var aDate = a?.LastUpdatedUtc ?? DateTime.MinValue;
+                    var bDate = b?.LastUpdatedUtc ?? DateTime.MinValue;
+                    int dateCmp = bDate.CompareTo(aDate);
+                    if (dateCmp != 0)
+                        return dateCmp;
                 }
 
                 if (hasSizeSort)
@@ -660,7 +694,8 @@ namespace Famille
                         Category = e.Category,
                         NormalizedName = e.NormalizedName,
                         FileSizeBytes = size,
-                        FileSizeText = FormatFileSize(size)
+                        FileSizeText = FormatFileSize(size),
+                        DocumentationAvailable = HasDocumentationFile(e.Path)
                     };
                 }).ToList();
 
@@ -749,24 +784,54 @@ namespace Famille
             if ((sender as MenuItem)?.DataContext is not FamilyItem fam)
                 return;
 
+            OpenDocumentationForFamily(fam, allowPrompt: true);
+        }
+
+        private void DocumentationBadge_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is not FamilyItem fam)
+                return;
+
+            OpenDocumentationForFamily(fam, allowPrompt: false);
+            e.Handled = true;
+        }
+
+        private void OpenDocumentationForFamily(FamilyItem fam, bool allowPrompt)
+        {
+            if (fam == null)
+                return;
+
             EnsureDocumentationLoaded(fam);
 
             if (!fam.HasDocumentation)
             {
-                if (!PromptAddDocumentation(fam))
+                if (allowPrompt)
                 {
+                    if (!PromptAddDocumentation(fam))
+                    {
+                        return;
+                    }
+
+                    if (!fam.HasDocumentation)
+                    {
+                        MessageBox.Show(this,
+                            "Aucun document n'a été associé à cette famille.",
+                            "Documentation",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Information);
+                        return;
+                    }
+                }
+                else
+                {
+                    fam.DocumentationAvailable = fam.HasDocumentation;
+                    MessageBox.Show(this,
+                        "Aucun document n'a été associé à cette famille.",
+                        "Documentation",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
                     return;
                 }
-            }
-
-            if (!fam.HasDocumentation)
-            {
-                MessageBox.Show(this,
-                    "Aucun document n'a été associé à cette famille.",
-                    "Documentation",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Information);
-                return;
             }
 
             if (fam.DocumentationLinks.Count == 1)
@@ -799,6 +864,8 @@ namespace Famille
             {
                 fam.DocumentationLinks.Add(link.Clone());
             }
+
+            fam.DocumentationAvailable = fam.DocumentationLinks.Count > 0;
         }
 
         private List<FamilyDocumentLink> LoadDocumentationFromDisk(string familyPath)
@@ -845,6 +912,12 @@ namespace Famille
 
         private static string GetDocumentationFilePath(string familyPath)
             => string.IsNullOrWhiteSpace(familyPath) ? null : familyPath + ".docs.json";
+
+        private static bool HasDocumentationFile(string familyPath)
+        {
+            var docFile = GetDocumentationFilePath(familyPath);
+            return !string.IsNullOrWhiteSpace(docFile) && File.Exists(docFile);
+        }
 
         private bool PromptAddDocumentation(FamilyItem fam)
         {
@@ -1269,6 +1342,241 @@ namespace Famille
             RefreshTop8_UsageOnly();
         }
 
+        private void CollectionActionsButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button)
+                return;
+
+            if (button.ContextMenu == null)
+                return;
+
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.Placement = PlacementMode.Bottom;
+            button.ContextMenu.IsOpen = true;
+        }
+
+        private void CollectionImportMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Title = "Importer une collection",
+                Filter = "Fichier JSON (*.json)|*.json|Tous les fichiers (*.*)|*.*",
+                CheckFileExists = true,
+                CheckPathExists = true,
+                Multiselect = false
+            };
+
+            if (dialog.ShowDialog(this) != true)
+                return;
+
+            try
+            {
+                var json = File.ReadAllText(dialog.FileName, Encoding.UTF8);
+                var payload = JsonConvert.DeserializeObject<CollectionExportPayload>(json);
+
+                if (payload == null)
+                {
+                    MessageBox.Show(this,
+                        "Le fichier sélectionné ne contient pas de collection valide.",
+                        "Import collection",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return;
+                }
+
+                var baseName = string.IsNullOrWhiteSpace(payload.Name)
+                    ? Path.GetFileNameWithoutExtension(dialog.FileName)
+                    : payload.Name.Trim();
+
+                var importedCollection = new Collection
+                {
+                    Name = GetUniqueCollectionName(baseName)
+                };
+
+                if (payload.Paths != null)
+                {
+                    var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var path in payload.Paths)
+                    {
+                        if (string.IsNullOrWhiteSpace(path))
+                            continue;
+
+                        var cleaned = path.Trim();
+                        if (unique.Add(cleaned))
+                            importedCollection.Paths.Add(cleaned);
+                    }
+                }
+
+                _collections.Add(importedCollection);
+                SaveCollections();
+                CollectionCombo.SelectedItem = importedCollection;
+
+                MessageBox.Show(this,
+                    $"Collection « {importedCollection.Name} » importée ({importedCollection.Paths.Count} éléments).",
+                    "Import collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this,
+                    "Impossible d'importer la collection :\n" + ex.Message,
+                    "Import collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        private void CollectionShareMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedCollection == null || _selectedCollection.Paths.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "Sélectionne une collection non vide avant de la partager.",
+                    "Collections",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            var defaultName = MakeSafeFileName(_selectedCollection.Name, "collection");
+
+            var dialog = new SaveFileDialog
+            {
+                Title = "Exporter la collection",
+                Filter = "Fichier JSON (*.json)|*.json|Tous les fichiers (*.*)|*.*",
+                FileName = defaultName + ".json"
+            };
+
+            if (dialog.ShowDialog(this) != true)
+                return;
+
+            try
+            {
+                var payload = new CollectionExportPayload
+                {
+                    Name = _selectedCollection.Name,
+                    Paths = _selectedCollection.Paths.ToList()
+                };
+
+                var json = JsonConvert.SerializeObject(payload, Formatting.Indented);
+                File.WriteAllText(dialog.FileName, json, Encoding.UTF8);
+
+                MessageBox.Show(this,
+                    $"Collection exportée vers :\n{dialog.FileName}",
+                    "Export collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this,
+                    "Impossible d'exporter la collection :\n" + ex.Message,
+                    "Export collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        private void CollectionDownloadMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedCollection == null || _selectedCollection.Paths.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "Sélectionne une collection non vide avant de télécharger les familles.",
+                    "Collections",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            using var dialog = new WinForms.FolderBrowserDialog
+            {
+                Description = "Choisir le dossier de destination"
+            };
+
+            if (dialog.ShowDialog() != WinForms.DialogResult.OK || string.IsNullOrWhiteSpace(dialog.SelectedPath))
+                return;
+
+            var targetFolder = dialog.SelectedPath;
+            try
+            {
+                Directory.CreateDirectory(targetFolder);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this,
+                    "Impossible de créer le dossier de destination :\n" + ex.Message,
+                    "Téléchargement de la collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                return;
+            }
+            int copied = 0;
+            var missing = new List<string>();
+            var errors = new List<string>();
+
+            foreach (var path in _selectedCollection.Paths)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                try
+                {
+                    if (!File.Exists(path))
+                    {
+                        missing.Add(Path.GetFileName(path));
+                        continue;
+                    }
+
+                    var fileName = Path.GetFileName(path);
+                    var destination = GetUniqueDestinationPath(targetFolder, fileName);
+                    if (destination == null)
+                    {
+                        errors.Add(fileName + " (chemin invalide)");
+                        continue;
+                    }
+
+                    File.Copy(path, destination, overwrite: false);
+                    copied++;
+                }
+                catch (Exception ex)
+                {
+                    errors.Add(Path.GetFileName(path) + " : " + ex.Message);
+                }
+            }
+
+            var summary = new StringBuilder();
+            summary.AppendLine($"Familles copiées : {copied}");
+            summary.AppendLine($"Destination : {targetFolder}");
+
+            if (missing.Count > 0)
+            {
+                summary.AppendLine();
+                summary.AppendLine("Introuvables :");
+                foreach (var name in missing.Take(10))
+                    summary.AppendLine(" - " + name);
+                if (missing.Count > 10)
+                    summary.AppendLine($" - (+ {missing.Count - 10} autres)");
+            }
+
+            if (errors.Count > 0)
+            {
+                summary.AppendLine();
+                summary.AppendLine("Erreurs de copie :");
+                foreach (var err in errors.Take(10))
+                    summary.AppendLine(" - " + err);
+                if (errors.Count > 10)
+                    summary.AppendLine($" - (+ {errors.Count - 10} autres)");
+            }
+
+            MessageBox.Show(this,
+                summary.ToString(),
+                "Téléchargement de la collection",
+                MessageBoxButton.OK,
+                errors.Count > 0 || missing.Count > 0 ? MessageBoxImage.Warning : MessageBoxImage.Information);
+        }
+
         private void CollectionLoad_Click(object sender, RoutedEventArgs e)
         {
             if (_selectedCollection == null || _selectedCollection.Paths.Count == 0) return;
@@ -1436,6 +1744,7 @@ namespace Famille
 
                     if (meta.UpdatedUtc.HasValue)
                     {
+                        fam.LastUpdatedUtc = meta.UpdatedUtc.Value;
                         try
                         {
                             var local = TimeZoneInfo.ConvertTimeFromUtc(meta.UpdatedUtc.Value, TimeZoneInfo.Local);
@@ -1448,11 +1757,13 @@ namespace Famille
                     }
                     else
                     {
+                        fam.LastUpdatedUtc = null;
                         fam.LastUpdatedText = null;
                     }
                 }
                 else
                 {
+                    fam.LastUpdatedUtc = null;
                     fam.LastUpdatedText = null;
                     fam.RevitSavedVersion = null;
                     if (string.IsNullOrWhiteSpace(fam.Category))
@@ -1461,6 +1772,7 @@ namespace Famille
 
                 if (!_isResorting &&
                     (_sizeSortDescending ||
+                     _dateSortDescending ||
                      !string.IsNullOrEmpty(ActiveCategoryFilter) ||
                      !string.IsNullOrEmpty(ActiveVersionFilter)))
                 {
@@ -1859,8 +2171,18 @@ namespace Famille
 
         private void DetailedViewCheckBox_Changed(object sender, RoutedEventArgs e)
         {
-            detailedViewMode = DetailedViewCheckBox?.IsChecked == true;
+            bool newMode = DetailedViewCheckBox?.IsChecked == true;
+            bool wasDateSortActive = _dateSortDescending;
+
+            detailedViewMode = newMode;
             UpdateFamilyListViewMode();
+
+            if (!newMode && wasDateSortActive)
+            {
+                _dateSortDescending = false;
+                NotifyPropertyChanged(nameof(IsDateSortActive));
+                ApplyFilters();
+            }
         }
 
         private void UpdateFamilyListViewMode()
@@ -1925,6 +2247,12 @@ namespace Famille
         #endregion
 
         #region Collections
+
+        private sealed class CollectionExportPayload
+        {
+            public string Name { get; set; }
+            public List<string> Paths { get; set; }
+        }
 
         private void LoadCollections()
         {
@@ -2171,6 +2499,73 @@ namespace Famille
             }
         }
 
+        private static string MakeSafeFileName(string name, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = fallback;
+
+            var invalid = Path.GetInvalidFileNameChars();
+            var sb = new StringBuilder(name.Length);
+            foreach (var ch in name)
+            {
+                sb.Append(invalid.Contains(ch) ? '_' : ch);
+            }
+
+            var result = sb.ToString().Trim();
+            if (string.IsNullOrEmpty(result))
+                result = fallback;
+
+            return result;
+        }
+
+        private string GetUniqueCollectionName(string desiredName)
+        {
+            if (string.IsNullOrWhiteSpace(desiredName))
+                desiredName = "Collection importée";
+
+            desiredName = desiredName.Trim();
+
+            var existingNames = _collections != null
+                ? new HashSet<string>(_collections.Select(c => c.Name), StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var baseName = desiredName;
+            int suffix = 2;
+
+            while (existingNames.Contains(desiredName)
+                   || string.Equals(desiredName, FavoritesCollectionName, StringComparison.OrdinalIgnoreCase))
+            {
+                desiredName = $"{baseName} ({suffix})";
+                suffix++;
+            }
+
+            return desiredName;
+        }
+
+        private static string GetUniqueDestinationPath(string folder, string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(folder))
+                return null;
+
+            if (string.IsNullOrWhiteSpace(fileName))
+                fileName = "fichier.rfa";
+
+            var baseName = Path.GetFileNameWithoutExtension(fileName);
+            var extension = Path.GetExtension(fileName) ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(baseName))
+                baseName = "fichier";
+
+            var candidate = Path.Combine(folder, baseName + extension);
+            int counter = 1;
+            while (File.Exists(candidate))
+            {
+                candidate = Path.Combine(folder, $"{baseName} ({counter}){extension}");
+                counter++;
+            }
+
+            return candidate;
+        }
+
         private FamilyItem CreateFamilyItemFromPath(string path)
         {
             var name = System.IO.Path.GetFileNameWithoutExtension(path);
@@ -2182,7 +2577,8 @@ namespace Famille
                 Icon = null,
                 NormalizedName = StripDiacritics(name).ToLowerInvariant(),
                 FileSizeBytes = size,
-                FileSizeText = FormatFileSize(size)
+                FileSizeText = FormatFileSize(size),
+                DocumentationAvailable = HasDocumentationFile(path)
             };
         }
 
@@ -2237,6 +2633,13 @@ namespace Famille
             set { if (_revitSavedVersion != value) { _revitSavedVersion = value; OnPropertyChanged(nameof(RevitSavedVersion)); } }
         }
 
+        private DateTime? _lastUpdatedUtc;
+        public DateTime? LastUpdatedUtc
+        {
+            get => _lastUpdatedUtc;
+            set { if (_lastUpdatedUtc != value) { _lastUpdatedUtc = value; OnPropertyChanged(nameof(LastUpdatedUtc)); } }
+        }
+
         private string _lastUpdatedText;
         public string LastUpdatedText
         {
@@ -2257,6 +2660,13 @@ namespace Famille
             set { if (_fileSizeBytes != value) { _fileSizeBytes = value; OnPropertyChanged(nameof(FileSizeBytes)); } }
         }
 
+        private bool _documentationAvailable;
+        public bool DocumentationAvailable
+        {
+            get => _documentationAvailable;
+            set { if (_documentationAvailable != value) { _documentationAvailable = value; OnPropertyChanged(nameof(DocumentationAvailable)); } }
+        }
+
         public ObservableCollection<FamilyDocumentLink> DocumentationLinks { get; }
 
         public bool HasDocumentation => DocumentationLinks?.Count > 0;
@@ -2265,6 +2675,7 @@ namespace Famille
         {
             OnPropertyChanged(nameof(DocumentationLinks));
             OnPropertyChanged(nameof(HasDocumentation));
+            DocumentationAvailable = DocumentationLinks?.Count > 0;
         }
 
 


### PR DESCRIPTION
## Summary
- restyle the documentation badge with a lighter template, icon, and hover states to better match the UI
- add a collection import option that reads exported JSON files, deduplicates paths, and selects the new collection
- reuse a typed payload for import/export and ensure imported collections get unique names

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6902393b8610832ea217c94c6fb67291