### PR TITLE
Improve family browser collection import and badge styling

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -74,16 +74,30 @@
         <Style x:Key="DocumentationBadgeStyle" TargetType="Button">
             <Setter Property="Content" Value="DOC"/>
             <Setter Property="FontSize" Value="10"/>
-            <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Padding" Value="6,3"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Padding" Value="8,4"/>
             <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Background" Value="#FF0063B1"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="Background" Value="#F0FFFFFF"/>
+            <Setter Property="Foreground" Value="#FF0F6EB8"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="#FF0F6EB8"/>
             <Setter Property="Visibility" Value="Collapsed"/>
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
             <Setter Property="ToolTip" Value="Ouvrir la documentation"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="12"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
             <Style.Triggers>
                 <DataTrigger Binding="{Binding DocumentationAvailable}" Value="True">
                     <Setter Property="Visibility" Value="Visible"/>
@@ -722,7 +736,7 @@
                                     <ContextMenu>
                                         <MenuItem Header="Partager la collection…"
                                                   Click="CollectionShareMenuItem_Click"/>
-                                        <MenuItem Header="Télécharger les familles…"
+                                        <MenuItem Header="Télécharger la collection…"
                                                   Click="CollectionDownloadMenuItem_Click"/>
                                     </ContextMenu>
                                 </Button.ContextMenu>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -530,6 +530,15 @@ namespace Famille
 
             result.Sort((a, b) =>
             {
+                if (hasDateSort)
+                {
+                    var aDate = a?.LastUpdatedUtc ?? DateTime.MinValue;
+                    var bDate = b?.LastUpdatedUtc ?? DateTime.MinValue;
+                    int dateCmp = bDate.CompareTo(aDate);
+                    if (dateCmp != 0)
+                        return dateCmp;
+                }
+
                 if (hasCategory)
                 {
                     int catCmp = CategoryMatches(b).CompareTo(CategoryMatches(a));
@@ -542,15 +551,6 @@ namespace Famille
                     int verCmp = VersionMatches(b).CompareTo(VersionMatches(a));
                     if (verCmp != 0)
                         return verCmp;
-                }
-
-                if (hasDateSort)
-                {
-                    var aDate = a?.LastUpdatedUtc ?? DateTime.MinValue;
-                    var bDate = b?.LastUpdatedUtc ?? DateTime.MinValue;
-                    int dateCmp = bDate.CompareTo(aDate);
-                    if (dateCmp != 0)
-                        return dateCmp;
                 }
 
                 if (hasSizeSort)
@@ -1408,101 +1408,85 @@ namespace Famille
 
         private void CollectionDownloadMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            if (_selectedCollection == null || _selectedCollection.Paths.Count == 0)
+            var dialog = new OpenFileDialog
             {
-                MessageBox.Show(this,
-                    "Sélectionne une collection non vide avant de télécharger les familles.",
-                    "Collections",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Information);
-                return;
-            }
-
-            using var dialog = new WinForms.FolderBrowserDialog
-            {
-                Description = "Choisir le dossier de destination"
+                Title = "Importer une collection",
+                Filter = "Fichier JSON (*.json)|*.json|Tous les fichiers (*.*)|*.*",
+                Multiselect = false,
+                CheckFileExists = true,
+                CheckPathExists = true
             };
 
-            if (dialog.ShowDialog() != WinForms.DialogResult.OK || string.IsNullOrWhiteSpace(dialog.SelectedPath))
+            if (dialog.ShowDialog(this) != true)
                 return;
 
-            var targetFolder = dialog.SelectedPath;
             try
             {
-                Directory.CreateDirectory(targetFolder);
+                var json = File.ReadAllText(dialog.FileName, Encoding.UTF8);
+                var payload = JsonConvert.DeserializeObject<SharedCollectionData>(json);
+
+                if (payload?.Paths == null || payload.Paths.Count == 0)
+                {
+                    MessageBox.Show(this,
+                        "Le fichier sélectionné ne contient aucune collection valide.",
+                        "Import de collection",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return;
+                }
+
+                var sanitizedPaths = payload.Paths
+                    .Where(p => !string.IsNullOrWhiteSpace(p))
+                    .Select(p => p.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (sanitizedPaths.Count == 0)
+                {
+                    MessageBox.Show(this,
+                        "Aucun chemin exploitable n'a été trouvé dans ce fichier.",
+                        "Import de collection",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return;
+                }
+
+                var desiredName = string.IsNullOrWhiteSpace(payload.Name)
+                    ? "Collection importée"
+                    : payload.Name.Trim();
+
+                if (string.Equals(desiredName, FavoritesCollectionName, StringComparison.OrdinalIgnoreCase))
+                    desiredName = desiredName + " (importée)";
+
+                var finalName = GenerateUniqueCollectionName(desiredName);
+
+                var imported = new Collection
+                {
+                    Name = finalName,
+                    Paths = sanitizedPaths
+                };
+
+                _collections.Add(imported);
+                SaveCollections();
+
+                _selectedCollection = imported;
+                CollectionCombo.SelectedItem = imported;
+                RefreshCollectionContent();
+
+                MessageBox.Show(this,
+                    $"Collection « {finalName} » importée ({sanitizedPaths.Count} élément(s)).",
+                    "Import de collection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
             }
             catch (Exception ex)
             {
                 MessageBox.Show(this,
-                    "Impossible de créer le dossier de destination :\n" + ex.Message,
-                    "Téléchargement de la collection",
+                    "Impossible d'importer la collection :\n" + ex.Message,
+                    "Import de collection",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
-                return;
             }
-            int copied = 0;
-            var missing = new List<string>();
-            var errors = new List<string>();
-
-            foreach (var path in _selectedCollection.Paths)
-            {
-                if (string.IsNullOrWhiteSpace(path))
-                    continue;
-
-                try
-                {
-                    if (!File.Exists(path))
-                    {
-                        missing.Add(Path.GetFileName(path));
-                        continue;
-                    }
-
-                    var fileName = Path.GetFileName(path);
-                    var destination = GetUniqueDestinationPath(targetFolder, fileName);
-                    if (destination == null)
-                    {
-                        errors.Add(fileName + " (chemin invalide)");
-                        continue;
-                    }
-
-                    File.Copy(path, destination, overwrite: false);
-                    copied++;
-                }
-                catch (Exception ex)
-                {
-                    errors.Add(Path.GetFileName(path) + " : " + ex.Message);
-                }
-            }
-
-            var summary = new StringBuilder();
-            summary.AppendLine($"Familles copiées : {copied}");
-            summary.AppendLine($"Destination : {targetFolder}");
-
-            if (missing.Count > 0)
-            {
-                summary.AppendLine();
-                summary.AppendLine("Introuvables :");
-                foreach (var name in missing.Take(10))
-                    summary.AppendLine(" - " + name);
-                if (missing.Count > 10)
-                    summary.AppendLine($" - (+ {missing.Count - 10} autres)");
-            }
-
-            if (errors.Count > 0)
-            {
-                summary.AppendLine();
-                summary.AppendLine("Erreurs de copie :");
-                foreach (var err in errors.Take(10))
-                    summary.AppendLine(" - " + err);
-                if (errors.Count > 10)
-                    summary.AppendLine($" - (+ {errors.Count - 10} autres)");
-            }
-
-            MessageBox.Show(this,
-                summary.ToString(),
-                "Téléchargement de la collection",
-                MessageBoxButton.OK,
-                errors.Count > 0 || missing.Count > 0 ? MessageBoxImage.Warning : MessageBoxImage.Information);
         }
 
         private void CollectionLoad_Click(object sender, RoutedEventArgs e)
@@ -2308,6 +2292,26 @@ namespace Famille
             }
         }
 
+        private string GenerateUniqueCollectionName(string desiredName)
+        {
+            if (string.IsNullOrWhiteSpace(desiredName))
+                desiredName = "Collection importée";
+
+            var baseName = desiredName.Trim();
+            if (string.Equals(baseName, FavoritesCollectionName, StringComparison.OrdinalIgnoreCase))
+                baseName += " (importée)";
+
+            string candidate = baseName;
+            int suffix = 2;
+            while (_collections.Any(c => string.Equals(c.Name, candidate, StringComparison.OrdinalIgnoreCase)))
+            {
+                candidate = $"{baseName} ({suffix})";
+                suffix++;
+            }
+
+            return candidate;
+        }
+
         // Ajout express -> collection active
         private void AddToActiveCollection_Click(object sender, RoutedEventArgs e)
         {
@@ -2444,31 +2448,6 @@ namespace Famille
                 result = fallback;
 
             return result;
-        }
-
-        private static string GetUniqueDestinationPath(string folder, string fileName)
-        {
-            if (string.IsNullOrWhiteSpace(folder))
-                return null;
-
-            if (string.IsNullOrWhiteSpace(fileName))
-                fileName = "fichier.rfa";
-
-            var baseName = Path.GetFileNameWithoutExtension(fileName);
-            var extension = Path.GetExtension(fileName) ?? string.Empty;
-
-            if (string.IsNullOrWhiteSpace(baseName))
-                baseName = "fichier";
-
-            var candidate = Path.Combine(folder, baseName + extension);
-            int counter = 1;
-            while (File.Exists(candidate))
-            {
-                candidate = Path.Combine(folder, $"{baseName} ({counter}){extension}");
-                counter++;
-            }
-
-            return candidate;
         }
 
         private FamilyItem CreateFamilyItemFromPath(string path)


### PR DESCRIPTION
## Summary
- restyle the documentation badge in the family browser to use a lighter pill appearance
- rename the collection menu entry and switch it to importing JSON collections instead of copying RFA folders
- ensure date sorting in the detailed view takes precedence over other interactive sorts and add a helper for unique collection names

## Testing
- dotnet build (fails: dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6903363d6750832e809f15c45a852b26