### PR TITLE
Refine Revit time dashboard filters and search

### DIFF
--- a/BIMaestro/app et excel/temps revit/ShowTimeDashboard.cs
+++ b/BIMaestro/app et excel/temps revit/ShowTimeDashboard.cs
@@ -13,7 +13,8 @@ namespace BIMaestro.Dashboard
             try
             {
                 Environment.SetEnvironmentVariable("EPPlusLicenseContext", "NonCommercial", EnvironmentVariableTarget.Process);
-                new TimeSeriesDashboardWindow().Show();
+                string activePath = cdata.Application?.ActiveUIDocument?.Document?.PathName;
+                new TimeSeriesDashboardWindow(activePath).Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/BIMaestro/app et excel/temps revit/TimeSeriesDashboardWindow.xaml
+++ b/BIMaestro/app et excel/temps revit/TimeSeriesDashboardWindow.xaml
@@ -1,9 +1,9 @@
-﻿<Window x:Class="BIMaestro.Dashboard.TimeSeriesDashboardWindow"
+<Window x:Class="BIMaestro.Dashboard.TimeSeriesDashboardWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf"
         Title="BIMaestro — Temps par projet"
-        Width="1220" Height="780" MinWidth="1080" MinHeight="660"
+        Width="1280" Height="820" MinWidth="1100" MinHeight="680"
         WindowStartupLocation="CenterScreen"
         Background="#F8F9FB">
 
@@ -155,107 +155,85 @@
         </Grid>
 
         <!-- ===== TOOLBAR ===== -->
-        <Grid Grid.Row="1" Margin="0,0,0,10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="430"/>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <!-- Dates -->
-            <StackPanel Grid.Column="0" Orientation="Vertical">
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                    <DatePicker x:Name="_dpFrom" Width="130" Margin="0,0,6,0" SelectedDateChanged="OnDateChanged"/>
-                    <DatePicker x:Name="_dpTo" Width="130" SelectedDateChanged="OnDateChanged"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Button Style="{StaticResource ChipButton}" Content="7 j" Click="Chip7_Click"/>
-                    <Button Style="{StaticResource ChipButton}" Content="30 j" Click="Chip30_Click"/>
-                    <Button Style="{StaticResource ChipButton}" Content="YTD" Click="ChipYtd_Click"/>
-                    <Button Style="{StaticResource ChipButton}" Content="12 mois" Click="Chip12m_Click"/>
-                    <Button Style="{StaticResource ChipButton}" Content="Tout" Click="ChipAll_Click"/>
-                </StackPanel>
-            </StackPanel>
-
-            <!-- Mode + tri + Top N -->
-            <StackPanel Grid.Column="1" Orientation="Vertical" Margin="8,0">
-                <Grid>
+        <Border Grid.Row="1" Style="{StaticResource CardBorder}" Margin="0,0,0,10">
+            <StackPanel Margin="16,12" Orientation="Vertical">
+                <Grid Margin="0,0,0,10">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                    </Grid.ColumnDefinitions>
-                    <ToggleButton x:Name="_tgOverview" Grid.Column="0" Style="{StaticResource SegmentToggle}" Content="Aperçu (barres)" Checked="Mode_Checked"/>
-                    <ToggleButton x:Name="_tgCompare"  Grid.Column="1" Style="{StaticResource SegmentToggle}" Content="Comparer (courbes)" Checked="Mode_Checked"/>
-                </Grid>
-
-                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <TextBlock Text="Trier :" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <ComboBox x:Name="_cbSort" Width="121.5" SelectionChanged="OnSortChanged">
-                        <ComboBoxItem Content="Heures ↓" IsSelected="True"/>
-                        <ComboBoxItem Content="Nom A→Z"/>
-                    </ComboBox>
-
-                    <TextBlock Text="  Top N :" VerticalAlignment="Center" Margin="4,0,6,0"/>
-                    <Button x:Name="_btnTopNMinus" Style="{StaticResource TinyButton}" Content="–" Click="BtnTopNMinus_Click"/>
-                    <TextBox x:Name="_tbTopN" Width="44" Height="26" Text="20" HorizontalContentAlignment="Center"
-                             PreviewTextInput="TopN_PreviewTextInput" TextChanged="TopN_TextChanged"/>
-                    <Button x:Name="_btnTopNPlus" Style="{StaticResource TinyButton}" Content="+" Click="BtnTopNPlus_Click"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                    <Button x:Name="_chipTop5"   Style="{StaticResource ChipButton}" Content="5"   Click="ChipTop_Click"/>
-                    <Button x:Name="_chipTop10"  Style="{StaticResource ChipButton}" Content="10"  Click="ChipTop_Click"/>
-                    <Button x:Name="_chipTop20"  Style="{StaticResource ChipButton}" Content="20"  Click="ChipTop_Click"/>
-                    <Button x:Name="_chipTop50"  Style="{StaticResource ChipButton}" Content="50"  Click="ChipTop_Click"/>
-                    <Button x:Name="_chipTop100" Style="{StaticResource ChipButton}" Content="100" Click="ChipTop_Click"/>
-                </StackPanel>
-            </StackPanel>
-
-            <!-- Recherche + actions -->
-            <Grid Grid.Column="2" Margin="8,0,0,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <Grid Grid.Row="0" Margin="0,0,0,6">
-                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="360"/>
+                        <ColumnDefinition Width="360"/>
                         <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <StackPanel>
-                        <TextBlock Text="Recherche (nom, dossier, fin de chemin)" Margin="0,0,0,4"/>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox x:Name="_tbSearch" Height="28" MinWidth="300"
-                                     ToolTip="Ctrl+F. Échap pour effacer. Accent-insensible."
-                                     KeyDown="Search_KeyDown" TextChanged="Search_TextChanged"/>
-                            <Button x:Name="_btnClearSearch" Grid.Column="1" Style="{StaticResource TinyButton}" Content="✕" Click="ClearSearch_Click"/>
-                        </Grid>
+
+                    <!-- Dates -->
+                    <StackPanel Grid.Column="0" Orientation="Vertical">
+                        <TextBlock Text="Période" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <DatePicker x:Name="_dpFrom" Width="140" Margin="0,0,6,0" SelectedDateChanged="OnDateChanged"/>
+                            <DatePicker x:Name="_dpTo" Width="140" SelectedDateChanged="OnDateChanged"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{StaticResource ChipButton}" Content="7 j" Click="Chip7_Click"/>
+                            <Button Style="{StaticResource ChipButton}" Content="30 j" Click="Chip30_Click"/>
+                            <Button Style="{StaticResource ChipButton}" Content="YTD" Click="ChipYtd_Click"/>
+                            <Button Style="{StaticResource ChipButton}" Content="12 m" Click="Chip12m_Click"/>
+                            <Button Style="{StaticResource ChipButton}" Content="Tout" Click="ChipAll_Click"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Mode + tri + Top N -->
+                    <StackPanel Grid.Column="1" Orientation="Vertical" Margin="10,0">
+                        <TextBlock Text="Affichage" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <StackPanel Orientation="Horizontal">
+                            <ToggleButton x:Name="_tgOverview" Style="{StaticResource SegmentToggle}" Content="Aperçu" Checked="Mode_Checked"/>
+                            <ToggleButton x:Name="_tgCompare"  Style="{StaticResource SegmentToggle}" Content="Comparer" Checked="Mode_Checked"/>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0" VerticalAlignment="Center">
+                            <TextBlock Text="Trier" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox x:Name="_cbSort" Width="120" SelectionChanged="OnSortChanged">
+                                <ComboBoxItem Content="Heures ↓" IsSelected="True"/>
+                                <ComboBoxItem Content="Nom A→Z"/>
+                            </ComboBox>
+
+                            <TextBlock Text="Top" VerticalAlignment="Center" Margin="10,0,6,0"/>
+                            <Button x:Name="_btnTopNMinus" Style="{StaticResource TinyButton}" Content="–" Click="BtnTopNMinus_Click"/>
+                            <TextBox x:Name="_tbTopN" Width="42" Height="26" Text="20" HorizontalContentAlignment="Center"
+                                     PreviewTextInput="TopN_PreviewTextInput" TextChanged="TopN_TextChanged"/>
+                            <Button x:Name="_btnTopNPlus" Style="{StaticResource TinyButton}" Content="+" Click="BtnTopNPlus_Click"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Actions principales -->
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                        <Button Style="{StaticResource GhostButton}" Content="Exporter PNG" Click="ExportPng_Click"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Exporter CSV" Click="ExportCsv_Click"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Ouvrir Excel" Click="OpenExcel_Click"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Réinitialiser" Click="Reset_Click"/>
                     </StackPanel>
                 </Grid>
 
-                <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Ouvrir Excel" Click="OpenExcel_Click"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Exporter CSV" Click="ExportCsv_Click"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Exporter PNG" Click="ExportPng_Click"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Réinitialiser" Click="Reset_Click"/>
+                <StackPanel Orientation="Horizontal" Margin="0,2,0,0" HorizontalAlignment="Stretch">
+                    <TextBlock Text="Temps par type de document" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center"/>
+                    <TabControl x:Name="_tabDocType" SelectionChanged="DocType_SelectionChanged" Background="Transparent" Margin="12,0,0,0" Width="260">
+                        <TabItem Header="Maquettes (.rvt)"/>
+                        <TabItem Header="Familles (.rfa)"/>
+                    </TabControl>
+                    <StackPanel Orientation="Horizontal" Margin="12,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="Légende" VerticalAlignment="Center"/>
+                        <CheckBox x:Name="_cbLegend" Content="Afficher" Margin="6,0,0,0" IsChecked="True" Checked="Legend_Checked" Unchecked="Legend_Checked"/>
+                    </StackPanel>
                 </StackPanel>
-            </Grid>
-        </Grid>
+            </StackPanel>
+        </Border>
 
         <!-- ===== BODY ===== -->
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="440"/>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="300"/>
+                <ColumnDefinition Width="380"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Liste projets -->
+            <!-- Visualisation -->
             <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="12">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -263,60 +241,80 @@
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <StackPanel Orientation="Horizontal" Margin="12,12,12,0">
-                        <TextBlock Text="Projets" FontWeight="SemiBold" FontSize="14" Margin="0,0,8,0"/>
-                        <CheckBox x:Name="_cbShowFolder" Content="Afficher dossier" IsChecked="False"
-                                  Checked="ShowFolder_Checked" Unchecked="ShowFolder_Checked"/>
-                    </StackPanel>
-
-                    <ListView x:Name="_lvProjects" Grid.Row="1" Margin="12" SelectionMode="Extended"
-                              AlternationCount="2" BorderThickness="0" Background="Transparent"
-                              ItemContainerStyle="{StaticResource ProjectItemStyle}"
-                              SelectionChanged="Projects_SelectionChanged" MouseDoubleClick="Projects_MouseDoubleClick">
-                        <ListView.View>
-                            <GridView>
-                                <GridViewColumn Header="Projet" Width="260" DisplayMemberBinding="{Binding BaseName}"/>
-                                <GridViewColumn x:Name="_colFolder" Header="Dossier" Width="0" DisplayMemberBinding="{Binding Folder}"/>
-                                <GridViewColumn Header="h" Width="60">
-                                    <GridViewColumn.DisplayMemberBinding>
-                                        <Binding Path="Hours" StringFormat="0.0"/>
-                                    </GridViewColumn.DisplayMemberBinding>
-                                </GridViewColumn>
-                            </GridView>
-                        </ListView.View>
-                    </ListView>
-
-                    <TextBlock x:Name="_lblCount" Grid.Row="2" Margin="12,0,12,12" Text="0 projet(s)"/>
-                </Grid>
-            </Border>
-
-            <!-- plus de Viewbox ni rotation -->
-            <Border Grid.Column="1" Style="{StaticResource CardBorder}" Margin="12">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <TextBlock Text="Visualisation du temps" FontWeight="SemiBold" FontSize="14" Margin="16,12,16,8"/>
+                    <TextBlock Text="Temps par type de document" FontWeight="SemiBold" FontSize="14" Margin="16,12,16,4"/>
                     <oxy:PlotView x:Name="_plotView" Grid.Row="1" Background="White" />
-                </Grid>
-            </Border>
-
-
-            <!-- Légende -->
-            <Border Grid.Column="2" Style="{StaticResource CardBorder}" Margin="12">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel Orientation="Horizontal" Margin="16,12,16,0">
-                        <TextBlock Text="Légende" FontWeight="SemiBold" FontSize="14"/>
-                        <CheckBox x:Name="_cbLegend" Content="Afficher" Margin="12,0,0,0" IsChecked="False" Checked="Legend_Checked" Unchecked="Legend_Checked"/>
+                    <StackPanel Grid.Row="2" Orientation="Vertical" Margin="12,0,12,12">
+                        <Border BorderBrush="{StaticResource NeutralBorder}" BorderThickness="1" Padding="10" CornerRadius="8" Background="#FDFEFE">
+                            <StackPanel>
+                                <TextBlock Text="Légende" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                                <ItemsControl x:Name="_legendList" ItemTemplate="{StaticResource LegendItemTemplate}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Vertical"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
-                    <ListView x:Name="_legendList" Grid.Row="1" Margin="12" ItemTemplate="{StaticResource LegendItemTemplate}"/>
                 </Grid>
             </Border>
+
+            <!-- Panneau latéral -->
+            <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Style="{StaticResource CardBorder}" Margin="12,12,12,6">
+                    <StackPanel Margin="14">
+                        <TextBlock Text="Recherche rapide" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Text="Tapez un nom de projet ou de famille pour accéder directement au dossier." Foreground="{StaticResource MutedText}" Margin="0,2,0,8"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox x:Name="_tbSearch" Height="32" MinWidth="260"
+                                     ToolTip="Ctrl+F. Échap pour effacer. Accent-insensible."
+                                     KeyDown="Search_KeyDown" TextChanged="Search_TextChanged"/>
+                            <Button x:Name="_btnClearSearch" Grid.Column="1" Style="{StaticResource TinyButton}" Content="✕" Click="ClearSearch_Click"/>
+                        </Grid>
+
+                        <ItemsControl x:Name="_icSuggestions" Margin="0,10,0,6">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Button Style="{StaticResource ChipButton}" Padding="12,6" Margin="0,4,6,4"
+                                            Content="{Binding BaseName}"
+                                            Tag="{Binding DocumentId}" Click="Suggestion_Click"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,0,0">
+                            <TextBlock x:Name="_lblCount" Margin="0,0,8,0" Text="0 résultat(s)"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="1" Style="{StaticResource CardBorder}" Margin="12,6,12,12">
+                    <StackPanel Margin="14">
+                        <TextBlock Text="Astuces" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Foreground="{StaticResource MutedText}" TextWrapping="Wrap" Margin="0,6,0,0">
+• Utilisez la barre de recherche pour filtrer les maquettes/familles.
+• Cliquez sur un résultat pour ouvrir rapidement son dossier.
+• Ajustez le Top N et le tri pour épurer les graphiques.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Grid>
     </Grid>
 </Window>

--- a/BIMaestro/app et excel/temps revit/TimeSeriesDashboardWindow.xaml.cs
+++ b/BIMaestro/app et excel/temps revit/TimeSeriesDashboardWindow.xaml.cs
@@ -5,6 +5,7 @@ using OxyPlot.Axes;
 using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -42,6 +43,8 @@ namespace BIMaestro.Dashboard
         // Debounce recherche
         private DispatcherTimer _searchDebounce;
 
+        private readonly string _currentDocumentPath;
+
         // ===== Data =====
         private List<LogRow> _rows = new();
         private List<ProjectItem> _projects = new();
@@ -54,14 +57,16 @@ namespace BIMaestro.Dashboard
 
         private enum SortMode { HoursDesc, NameAZ }
         private enum AutoGran { Day, Week, Month }
+        private enum DocumentKind { Rvt, Rfa }
 
         private Prefs _prefs = new();
 
-        public TimeSeriesDashboardWindow()
+        public TimeSeriesDashboardWindow(string currentDocumentPath = null)
         {
             InitializeComponent();
 
-            Title = "BIMaestro — Temps par projet";
+            _currentDocumentPath = currentDocumentPath;
+            Title = "BIMaestro — Temps par type de document";
             AddHotkeys();
 
             _searchDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(220) };
@@ -71,6 +76,7 @@ namespace BIMaestro.Dashboard
             _dpTo.SelectedDate = DateTime.Today;
             _tgOverview.IsChecked = true;
             _tgCompare.IsChecked = false;
+            _tabDocType.SelectedIndex = 0;
 
             Environment.SetEnvironmentVariable("EPPlusLicenseContext", "NonCommercial", EnvironmentVariableTarget.Process);
 
@@ -95,7 +101,6 @@ namespace BIMaestro.Dashboard
             InputBindings.Add(new KeyBinding(new RelayCommand(_ => CopyChartToClipboard()), new KeyGesture(Key.C, ModifierKeys.Control)));
             InputBindings.Add(new KeyBinding(new RelayCommand(_ => ExportCsv()), new KeyGesture(Key.C, ModifierKeys.Control | ModifierKeys.Shift)));
             InputBindings.Add(new KeyBinding(new RelayCommand(_ => ResetFilters()), new KeyGesture(Key.R, ModifierKeys.Control)));
-            InputBindings.Add(new KeyBinding(new RelayCommand(_ => _lvProjects.SelectAll()), new KeyGesture(Key.A, ModifierKeys.Control)));
         }
 
         // ===== Handlers XAML (ils doivent garder leur NOM exact) =====
@@ -110,32 +115,13 @@ namespace BIMaestro.Dashboard
             DrawChart();
         }
 
+        private void DocType_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_uiReady) return;
+            RefreshAll();
+        }
+
         private void Legend_Checked(object sender, RoutedEventArgs e) { if (!_uiReady) return; DrawChart(); }
-
-        private void Projects_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (!_uiReady) return;
-            DrawChart();
-            UpdateKpis();
-        }
-
-        private void Projects_MouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            if (!_uiReady) return;
-            if (_lvProjects.SelectedItem is ProjectItem it)
-            {
-                _lvProjects.SelectedItems.Clear();
-                _lvProjects.SelectedItems.Add(it);
-                DrawChart();
-                UpdateKpis();
-            }
-        }
-
-        private void ShowFolder_Checked(object sender, RoutedEventArgs e)
-        {
-            if (!_uiReady) return;
-            _colFolder.Width = (_cbShowFolder.IsChecked == true) ? 140 : 0;
-        }
 
         private void Search_KeyDown(object sender, KeyEventArgs e)
         {
@@ -144,6 +130,23 @@ namespace BIMaestro.Dashboard
         }
         private void Search_TextChanged(object sender, TextChangedEventArgs e) { if (!_uiReady) return; _searchDebounce.Start(); }
         private void ClearSearch_Click(object sender, RoutedEventArgs e) { if (!_uiReady) return; _tbSearch.Text = ""; _tbSearch.Focus(); }
+
+        private void OpenLocation_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_uiReady) return;
+            TryOpenLocation();
+        }
+
+        private void Suggestion_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_uiReady) return;
+            if (sender is Button btn)
+            {
+                _tbSearch.Text = btn.Content?.ToString() ?? string.Empty;
+                string path = btn.Tag?.ToString();
+                TryOpenLocation(path);
+            }
+        }
 
         private void Chip7_Click(object s, RoutedEventArgs e) { if (!_uiReady) return; SetRange(DateTime.Today.AddDays(-7), DateTime.Today); }
         private void Chip30_Click(object s, RoutedEventArgs e) { if (!_uiReady) return; SetRange(DateTime.Today.AddDays(-30), DateTime.Today); }
@@ -199,6 +202,24 @@ namespace BIMaestro.Dashboard
             }
         }
 
+        private DocumentKind GetActiveKind() => (_tabDocType?.SelectedIndex == 1) ? DocumentKind.Rfa : DocumentKind.Rvt;
+
+        private static DocumentKind GetKind(string documentId, string documentName)
+        {
+            string id = (documentId ?? string.Empty).ToLowerInvariant();
+            string name = (documentName ?? string.Empty).ToLowerInvariant();
+            if (id.EndsWith(".rfa") || name.EndsWith(".rfa")) return DocumentKind.Rfa;
+            return DocumentKind.Rvt;
+        }
+
+        private bool MatchesDocumentKind(ProjectItem item) => MatchesDocumentKind(item?.DocumentId, item?.Name);
+
+        private bool MatchesDocumentKind(string documentId, string documentName)
+        {
+            var active = GetActiveKind();
+            return GetKind(documentId, documentName) == active;
+        }
+
         private void BuildProjectList()
         {
             var closed = _rows.Where(r => string.Equals(r.Event, "Fermé", StringComparison.OrdinalIgnoreCase));
@@ -228,6 +249,7 @@ namespace BIMaestro.Dashboard
 
             _hoursByProject = _rows
                 .Where(r => r.Event.Equals("Fermé", StringComparison.OrdinalIgnoreCase))
+                .Where(r => MatchesDocumentKind(r.DocumentId, r.DocumentName))
                 .Where(r => !d0.HasValue || r.When >= d0.Value)
                 .Where(r => !d1.HasValue || r.When <= d1.Value)
                 .GroupBy(r => r.DocumentId)
@@ -244,6 +266,7 @@ namespace BIMaestro.Dashboard
             SortMode sm = (_cbSort != null && _cbSort.SelectedIndex == 1) ? SortMode.NameAZ : SortMode.HoursDesc;
 
             IEnumerable<ProjectItem> seq = _projects ?? Enumerable.Empty<ProjectItem>();
+            seq = seq.Where(MatchesDocumentKind);
             foreach (var p in seq)
                 p.Hours = _hoursByProject.TryGetValue(p.DocumentId, out double h) ? h : 0.0;
 
@@ -259,14 +282,10 @@ namespace BIMaestro.Dashboard
                 ? seq.OrderByDescending(p => p.Hours).ThenBy(p => p.BaseName).ToList()
                 : seq.OrderBy(p => p.BaseName).ThenBy(p => p.Folder).ToList();
 
-            if (_lvProjects != null)
-            {
-                _lvProjects.ItemsSource = _filteredProjects;
-                _lblCount.Text = _filteredProjects.Count + " projet(s)";
+            _lblCount.Text = _filteredProjects.Count + " résultat(s)";
 
-                if (string.IsNullOrEmpty(q) && _filteredProjects.Count > 0 && _lvProjects.SelectedItems.Count == 0)
-                    _lvProjects.SelectAll();
-            }
+            if (_icSuggestions != null)
+                _icSuggestions.ItemsSource = _filteredProjects.Take(10).ToList();
         }
 
         // ===== CHART =====
@@ -276,15 +295,14 @@ namespace BIMaestro.Dashboard
 
             var model = new PlotModel();
 
-            var selected = _lvProjects?.SelectedItems.Cast<ProjectItem>().ToList()
-                           ?? new List<ProjectItem>();
-            if (selected.Count == 0)
-                selected = (_filteredProjects?.Count > 0 ? _filteredProjects : _projects).ToList();
+            var selected = (_filteredProjects?.Count > 0 ? _filteredProjects : _projects).ToList();
 
             DateTime? d0 = _dpFrom.SelectedDate;
             DateTime? d1 = _dpTo.SelectedDate?.AddDays(1).AddTicks(-1);
 
-            IEnumerable<LogRow> closed = _rows.Where(r => r.Event.Equals("Fermé", StringComparison.OrdinalIgnoreCase));
+            IEnumerable<LogRow> closed = _rows
+                .Where(r => r.Event.Equals("Fermé", StringComparison.OrdinalIgnoreCase))
+                .Where(r => MatchesDocumentKind(r.DocumentId, r.DocumentName));
             if (d0.HasValue) closed = closed.Where(r => r.When >= d0.Value);
             if (d1.HasValue) closed = closed.Where(r => r.When <= d1.Value);
 
@@ -430,9 +448,10 @@ namespace BIMaestro.Dashboard
         // ===== KPI =====
         private void UpdateKpis()
         {
-            if (_lvProjects == null) return;
+            var selectedItems = (_filteredProjects?.Count > 0 ? _filteredProjects : _projects).ToList();
+            if (selectedItems.Count == 0) return;
 
-            var selected = new HashSet<string>(_lvProjects.SelectedItems.Cast<ProjectItem>().Select(p => p.DocumentId));
+            var selected = new HashSet<string>(selectedItems.Select(p => p.DocumentId));
             DateTime d0 = _dpFrom.SelectedDate ?? DateTime.MinValue;
             DateTime d1 = _dpTo.SelectedDate.HasValue ? _dpTo.SelectedDate.Value.AddDays(1).AddTicks(-1) : DateTime.MaxValue;
 
@@ -448,7 +467,7 @@ namespace BIMaestro.Dashboard
             int workedWeekdays = inRangeWeekdays.Select(r => r.When.Date).Distinct().Count();
             double avg = workedWeekdays == 0 ? 0.0 : totalH / workedWeekdays;
 
-            int projects = _lvProjects.SelectedItems.Count;
+            int projects = selectedItems.Count;
             _kpiHours.Text = totalH.ToString("0.0") + " h";
             _kpiProjects.Text = projects.ToString();
             _kpiAvg.Text = avg.ToString("0.0") + " h";
@@ -473,7 +492,7 @@ namespace BIMaestro.Dashboard
             var dlg = new Microsoft.Win32.SaveFileDialog { FileName = "dashboard_temps.csv", Filter = "CSV|*.csv" };
             if (dlg.ShowDialog() != true) return;
 
-            var selected = new HashSet<string>(_lvProjects.SelectedItems.Cast<ProjectItem>().Select(p => p.DocumentId));
+            var selected = new HashSet<string>((_filteredProjects?.Count > 0 ? _filteredProjects : _projects).Select(p => p.DocumentId));
             DateTime d0 = _dpFrom.SelectedDate ?? DateTime.MinValue;
             DateTime d1 = _dpTo.SelectedDate.HasValue ? _dpTo.SelectedDate.Value.AddDays(1).AddTicks(-1) : DateTime.MaxValue;
 
@@ -518,6 +537,43 @@ namespace BIMaestro.Dashboard
             catch (Exception ex) { MessageBox.Show(ex.Message); }
         }
 
+        private void TryOpenLocation(string preferredPath = null)
+        {
+            try
+            {
+                string path = null;
+                if (!string.IsNullOrWhiteSpace(preferredPath))
+                    path = preferredPath;
+                else
+                {
+                    var firstMatch = _filteredProjects?.FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(_tbSearch?.Text) && firstMatch != null)
+                        path = firstMatch.DocumentId;
+                    else if (!string.IsNullOrWhiteSpace(_currentDocumentPath))
+                        path = _currentDocumentPath;
+                }
+
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    MessageBox.Show("Aucun chemin détecté pour ouvrir l'emplacement.");
+                    return;
+                }
+
+                string folder = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
+                if (string.IsNullOrWhiteSpace(folder) || !Directory.Exists(folder))
+                {
+                    MessageBox.Show("Dossier introuvable pour : " + path);
+                    return;
+                }
+
+                Process.Start(new ProcessStartInfo { FileName = folder, UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+        }
+
         private void ResetFilters()
         {
             _tbSearch.Text = "";
@@ -526,10 +582,9 @@ namespace BIMaestro.Dashboard
             _dpFrom.SelectedDate = DateTime.Today.AddMonths(-1);
             _dpTo.SelectedDate = DateTime.Today;
             _tgOverview.IsChecked = true; _tgCompare.IsChecked = false;
-            _cbLegend.IsChecked = false;
-            _cbShowFolder.IsChecked = false;
+            _cbLegend.IsChecked = true;
+            _tabDocType.SelectedIndex = 0;
             _hiddenBars.Clear();
-            _lvProjects.SelectAll();
             RefreshAll();
         }
 
@@ -556,8 +611,7 @@ namespace BIMaestro.Dashboard
                 _tgOverview.IsChecked = _prefs.Mode != "Compare";
                 _tgCompare.IsChecked = _prefs.Mode == "Compare";
                 _cbLegend.IsChecked = _prefs.LegendShown;
-                _cbShowFolder.IsChecked = _prefs.ShowFolder;
-                _colFolder.Width = (_prefs.ShowFolder ? 140 : 0);
+                _tabDocType.SelectedIndex = _prefs.DocType == "Rfa" ? 1 : 0;
             }
             catch { }
         }
@@ -573,7 +627,7 @@ namespace BIMaestro.Dashboard
                 _prefs.TopN = GetTopN();
                 _prefs.Mode = _tgCompare.IsChecked == true ? "Compare" : "Overview";
                 _prefs.LegendShown = _cbLegend.IsChecked == true;
-                _prefs.ShowFolder = _cbShowFolder.IsChecked == true;
+                _prefs.DocType = GetActiveKind() == DocumentKind.Rfa ? "Rfa" : "Rvt";
                 File.WriteAllText(PrefsPath, JsonConvert.SerializeObject(_prefs, Formatting.Indented), Encoding.UTF8);
             }
             catch { }
@@ -781,8 +835,8 @@ namespace BIMaestro.Dashboard
             public string Sort { get; set; } = "HoursDesc";
             public int TopN { get; set; } = DEFAULT_TOP_N;
             public string Mode { get; set; } = "Overview";
-            public bool LegendShown { get; set; } = false;
-            public bool ShowFolder { get; set; } = false;
+            public bool LegendShown { get; set; } = true;
+            public string DocType { get; set; } = "Rvt";
         }
 
         [Obfuscation(Exclude = true, ApplyToMembers = true, StripAfterObfuscation = false)]


### PR DESCRIPTION
## Summary
- embed document-type selection beside the chart heading, rename the view, and surface the legend directly under the plot
- simplify the toolbar with clearer date/top controls and refreshed action buttons
- replace the project list with quick search suggestions that open locations faster

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b31bc8e28832eb77ae51e7b0d45f2)