### PR TITLE
Add multi-selection support, selection-aware actions and UI tweaks to Family browser

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -141,9 +141,20 @@
                 <Border Margin="5" Width="200"
                     Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
-                    BorderBrush="#33000000"
                     BorderThickness="1"
-                    MouseLeftButtonDown="FamilyItem_DoubleClick">
+                    MouseLeftButtonDown="FamilyItem_DoubleClick"
+                    PreviewMouseRightButtonDown="FamilyItem_RightClickSelect">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="BorderBrush" Value="#33000000"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter Property="BorderBrush" Value="#FF2D8CFF"/>
+                                    <Setter Property="BorderThickness" Value="2"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <Border.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Documentation"
@@ -162,6 +173,12 @@
                             <!-- Ajout express dans la collection active -->
                             <MenuItem Header="Ajouter à la collection active"
                                   Click="AddToActiveCollection_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            <MenuItem Header="Ajouter la sélection à la collection active"
+                                  Click="AddSelectionToActiveCollection_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            <MenuItem Header="Charger la sélection"
+                                  Click="LoadSelection_Click"
                                   DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         </ContextMenu>
                     </Border.ContextMenu>
@@ -242,10 +259,21 @@
                 <Border Margin="5"
                     Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
-                    BorderBrush="#33000000"
                     BorderThickness="1"
                     MouseLeftButtonDown="FamilyItem_DoubleClick"
+                    PreviewMouseRightButtonDown="FamilyItem_RightClickSelect"
                     HorizontalAlignment="Stretch">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="BorderBrush" Value="#33000000"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter Property="BorderBrush" Value="#FF2D8CFF"/>
+                                    <Setter Property="BorderThickness" Value="2"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <Border.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Documentation"
@@ -263,6 +291,12 @@
 
                             <MenuItem Header="Ajouter à la collection active"
                                   Click="AddToActiveCollection_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            <MenuItem Header="Ajouter la sélection à la collection active"
+                                  Click="AddSelectionToActiveCollection_Click"
+                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            <MenuItem Header="Charger la sélection"
+                                  Click="LoadSelection_Click"
                                   DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         </ContextMenu>
                     </Border.ContextMenu>
@@ -737,6 +771,12 @@
                                           Foreground="{DynamicResource PrimaryText}"
                                           Checked="DetailedViewCheckBox_Changed"
                                           Unchecked="DetailedViewCheckBox_Changed" Width="92"/>
+                                <CheckBox x:Name="MultiSelectCheckBox"
+                                          Content="Sélection multiple"
+                                          Foreground="{DynamicResource PrimaryText}"
+                                          Margin="0,0,8,0"
+                                          Checked="MultiSelectCheckBox_Changed"
+                                          Unchecked="MultiSelectCheckBox_Changed"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                                 <TextBlock Foreground="{DynamicResource PrimaryText}" Margin="5,0,0,0" Text="Familles affichées : "/>
@@ -815,7 +855,11 @@
             <TabItem x:Name="SettingsTabItem"
                      Header="Paramètres"
                      Background="{DynamicResource TabBackground}">
-                <Grid x:Name="SettingsPanelRoot" Margin="12,10,8,10" Background="Transparent">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled"
+                              Padding="0"
+                              Focusable="False">
+                    <Grid x:Name="SettingsPanelRoot" Margin="12,10,8,10" Background="Transparent">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -1092,7 +1136,8 @@
                             </StackPanel>
                         </Grid>
                     </Border>
-                </Grid>
+                    </Grid>
+                </ScrollViewer>
             </TabItem>
 
         </TabControl>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -60,6 +60,8 @@ namespace Famille
         private bool _sizeSortDescending;
         private bool _dateSortDescending;
         private bool _isResorting;
+        private bool _isMultiSelectionEnabled;
+        private FamilyItem _lastSelectedFamily;
 
         // ===== Données UI =====
         private List<FamilyItem> allFamilies = new();
@@ -754,6 +756,9 @@ namespace Famille
 
         private void BeginPaging(List<FamilyItem> fullResult)
         {
+            ClearSelectedFamilies();
+            _lastSelectedFamily = null;
+
             _currentResult = fullResult ?? new List<FamilyItem>();
             _nextIndex = 0;
             displayedFamilies = new List<FamilyItem>();
@@ -1316,12 +1321,106 @@ namespace Famille
 
         private void FamilyItem_DoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (e.ClickCount != 2) return;
-            if (sender is Border b && b.DataContext is FamilyItem fam)
+            if (sender is not Border b || b.DataContext is not FamilyItem fam)
+                return;
+
+            if (_isMultiSelectionEnabled)
             {
-                FamilyBrowserCommand.LoadFamilyHandlerInstance.FamilyPath = fam.Path;
-                FamilyBrowserCommand.LoadFamilyEventInstance.Raise();
+                if (e.ClickCount == 1)
+                {
+                    SelectFamilyFromClick(fam, Keyboard.Modifiers);
+                    e.Handled = true;
+                }
+                return;
             }
+
+            if (e.ClickCount != 2) return;
+            FamilyBrowserCommand.LoadFamilyHandlerInstance.FamilyPath = fam.Path;
+            FamilyBrowserCommand.LoadFamilyEventInstance.Raise();
+        }
+
+        private void FamilyItem_RightClickSelect(object sender, MouseButtonEventArgs e)
+        {
+            if (!_isMultiSelectionEnabled) return;
+            if (sender is not Border b || b.DataContext is not FamilyItem fam) return;
+
+            var selectedFamilies = GetSelectedFamilies();
+            if (!selectedFamilies.Contains(fam))
+            {
+                SelectFamilyFromClick(fam, ModifierKeys.None);
+            }
+        }
+
+        private void MultiSelectCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            _isMultiSelectionEnabled = MultiSelectCheckBox?.IsChecked == true;
+            if (!_isMultiSelectionEnabled)
+            {
+                ClearSelectedFamilies();
+                _lastSelectedFamily = null;
+            }
+        }
+
+        private void SelectFamilyFromClick(FamilyItem clickedFamily, ModifierKeys modifiers)
+        {
+            if (clickedFamily == null) return;
+
+            bool shift = (modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
+            bool ctrl = (modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+
+            if (shift && _lastSelectedFamily != null)
+            {
+                int start = displayedFamilies.IndexOf(_lastSelectedFamily);
+                int end = displayedFamilies.IndexOf(clickedFamily);
+                if (start >= 0 && end >= 0)
+                {
+                    if (!ctrl)
+                        ClearSelectedFamilies();
+
+                    int min = Math.Min(start, end);
+                    int max = Math.Max(start, end);
+                    for (int i = min; i <= max; i++)
+                        displayedFamilies[i].IsSelected = true;
+                }
+                else
+                {
+                    if (!ctrl)
+                        ClearSelectedFamilies();
+                    clickedFamily.IsSelected = true;
+                }
+            }
+            else if (ctrl)
+            {
+                clickedFamily.IsSelected = !clickedFamily.IsSelected;
+            }
+            else
+            {
+                ClearSelectedFamilies();
+                clickedFamily.IsSelected = true;
+            }
+
+            _lastSelectedFamily = clickedFamily;
+        }
+
+        private List<FamilyItem> GetSelectedFamilies()
+            => displayedFamilies.Where(f => f.IsSelected).ToList();
+
+        private List<FamilyItem> GetEffectiveSelection(FamilyItem contextFamily = null)
+        {
+            var selected = GetSelectedFamilies();
+            if (selected.Count > 0)
+                return selected;
+
+            if (contextFamily != null)
+                return new List<FamilyItem> { contextFamily };
+
+            return new List<FamilyItem>();
+        }
+
+        private void ClearSelectedFamilies()
+        {
+            foreach (var family in displayedFamilies.Where(f => f.IsSelected))
+                family.IsSelected = false;
         }
 
         private void OpenFamilyFile_Click(object sender, RoutedEventArgs e)
@@ -2620,22 +2719,63 @@ namespace Famille
         private void AddToActiveCollection_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuItem)?.DataContext is not FamilyItem fam) return;
+            AddFamiliesToActiveCollection(GetEffectiveSelection(fam));
+        }
+
+        private void AddSelectionToActiveCollection_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuItem)?.DataContext is not FamilyItem fam) return;
+            AddFamiliesToActiveCollection(GetEffectiveSelection(fam));
+        }
+
+        private void AddFamiliesToActiveCollection(IEnumerable<FamilyItem> families)
+        {
+            var familyList = families?.Where(f => f != null).ToList() ?? new List<FamilyItem>();
+            if (familyList.Count == 0) return;
 
             if (_selectedCollection == null)
                 EnsureFavoritesCollection();
 
-            if (!_selectedCollection.Paths.Any(p => p.Equals(fam.Path, StringComparison.OrdinalIgnoreCase)))
+            bool updated = false;
+            foreach (var fam in familyList)
             {
+                if (_selectedCollection.Paths.Any(p => p.Equals(fam.Path, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
                 _selectedCollection.Paths.Add(fam.Path);
-                SaveCollections();
-                RefreshCollectionContent();
+                updated = true;
 
                 if (_selectedCollection.Id == FavoritesCollectionId)
-                {
                     fam.IsFavorite = true;
+            }
+
+            if (updated)
+            {
+                SaveCollections();
+                RefreshCollectionContent();
+                if (_selectedCollection.Id == FavoritesCollectionId)
+                {
                     ExportFavoritesCollectionToTxt();
                 }
             }
+        }
+
+        private void LoadSelection_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuItem)?.DataContext is not FamilyItem fam) return;
+            var selectedFamilies = GetEffectiveSelection(fam);
+            if (selectedFamilies.Count == 0) return;
+
+            var paths = selectedFamilies
+                .Select(f => f.Path)
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (paths.Count == 0) return;
+
+            FamilyBrowserCommand.LoadCollectionHandlerInstance.FamilyPaths = paths;
+            FamilyBrowserCommand.LoadCollectionEventInstance.Raise();
         }
 
         // 🗑 : retirer un élément de la collection sélectionnée
@@ -2849,6 +2989,13 @@ namespace Famille
         {
             get => _isFavorite;
             set { if (_isFavorite != value) { _isFavorite = value; OnPropertyChanged(nameof(IsFavorite)); } }
+        }
+
+        private bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set { if (_isSelected != value) { _isSelected = value; OnPropertyChanged(nameof(IsSelected)); } }
         }
 
         private string _revitSavedVersion;


### PR DESCRIPTION
### Motivation
- Allow users to select multiple family items to perform batch actions like adding to a collection or loading a set of families, and to improve discoverability/feedback for selection in the UI. 
- Provide context-menu operations that act on the current selection rather than a single item. 
- Make the settings panel scrollable to avoid clipping when content overflows.

### Description
- Implemented multi-selection support including a `MultiSelectCheckBox`, selection state on `FamilyItem` (`IsSelected`), visual selection highlighting via `Border.Style`, right-click-to-select handler `FamilyItem_RightClickSelect`, and selection logic in `SelectFamilyFromClick` (supports Shift and Ctrl modifiers) and helpers `GetSelectedFamilies`, `GetEffectiveSelection`, and `ClearSelectedFamilies`.
- Added selection-aware actions and menu items: `Ajouter la sélection à la collection active` (`AddSelectionToActiveCollection_Click`) and `Charger la sélection` (`LoadSelection_Click`), and consolidated adding to collection into `AddFamiliesToActiveCollection` which updates favorites and saves collections appropriately.
- Adjusted click behavior so single clicks select when multi-select mode is enabled and double-click loads a family when disabled; `BeginPaging` now clears selection when refreshing results.
- Wrapped the settings `Grid` in a `ScrollViewer` to allow vertical scrolling of settings content and applied small UI reorganizations in templates (context menu additions and selection visuals).

### Testing
- No automated tests were added or modified for this change.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e428f1c832e9e83273800864bb8)