### PR TITLE
Add multi-selection, batch actions and selection UI to Family Browser

### DIFF
--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml
@@ -141,9 +141,22 @@
                 <Border Margin="5" Width="200"
                     Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
-                    BorderBrush="#33000000"
                     BorderThickness="1"
-                    MouseLeftButtonDown="FamilyItem_DoubleClick">
+                    MouseLeftButtonDown="FamilyItem_DoubleClick"
+                    PreviewMouseRightButtonDown="FamilyItem_RightClickSelect"
+                    ContextMenuOpening="FamilyItem_ContextMenuOpening">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="BorderBrush" Value="#33000000"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter Property="BorderBrush" Value="{DynamicResource Brand}"/>
+                                    <Setter Property="BorderThickness" Value="3"/>
+                                    <Setter Property="Background" Value="#1F0F5132"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <Border.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Documentation"
@@ -242,10 +255,23 @@
                 <Border Margin="5"
                     Background="{DynamicResource PanelBackground}"
                     CornerRadius="5"
-                    BorderBrush="#33000000"
                     BorderThickness="1"
                     MouseLeftButtonDown="FamilyItem_DoubleClick"
+                    PreviewMouseRightButtonDown="FamilyItem_RightClickSelect"
+                    ContextMenuOpening="FamilyItem_ContextMenuOpening"
                     HorizontalAlignment="Stretch">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="BorderBrush" Value="#33000000"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter Property="BorderBrush" Value="{DynamicResource Brand}"/>
+                                    <Setter Property="BorderThickness" Value="3"/>
+                                    <Setter Property="Background" Value="#1F0F5132"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <Border.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Documentation"
@@ -731,9 +757,15 @@
                                     </Button.Style>
                                 </Button>
 
+                                <CheckBox x:Name="MultiSelectCheckBox"
+                                          Content="Sélection multiple"
+                                          Foreground="{DynamicResource PrimaryText}"
+                                          Margin="0,0,20,0"
+                                          Checked="MultiSelectCheckBox_Changed"
+                                          Unchecked="MultiSelectCheckBox_Changed"/>
                                 <CheckBox x:Name="DetailedViewCheckBox"
                                           Content="Vue détaillée"
-                                          Margin="0,0,20,0"
+                                          Margin="0,0,8,0"
                                           Foreground="{DynamicResource PrimaryText}"
                                           Checked="DetailedViewCheckBox_Changed"
                                           Unchecked="DetailedViewCheckBox_Changed" Width="92"/>
@@ -815,7 +847,11 @@
             <TabItem x:Name="SettingsTabItem"
                      Header="Paramètres"
                      Background="{DynamicResource TabBackground}">
-                <Grid x:Name="SettingsPanelRoot" Margin="12,10,8,10" Background="Transparent">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled"
+                              Padding="0"
+                              Focusable="False">
+                    <Grid x:Name="SettingsPanelRoot" Margin="12,10,8,10" Background="Transparent">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -1092,7 +1128,8 @@
                             </StackPanel>
                         </Grid>
                     </Border>
-                </Grid>
+                    </Grid>
+                </ScrollViewer>
             </TabItem>
 
         </TabControl>

--- a/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
+++ b/BIMaestro/commands/Dossier famille/FamilyBrowserPlugin.xaml.cs
@@ -60,6 +60,8 @@ namespace Famille
         private bool _sizeSortDescending;
         private bool _dateSortDescending;
         private bool _isResorting;
+        private bool _isMultiSelectionEnabled;
+        private FamilyItem _lastSelectedFamily;
 
         // ===== Données UI =====
         private List<FamilyItem> allFamilies = new();
@@ -754,6 +756,9 @@ namespace Famille
 
         private void BeginPaging(List<FamilyItem> fullResult)
         {
+            ClearSelectedFamilies();
+            _lastSelectedFamily = null;
+
             _currentResult = fullResult ?? new List<FamilyItem>();
             _nextIndex = 0;
             displayedFamilies = new List<FamilyItem>();
@@ -1300,7 +1305,14 @@ namespace Famille
         {
             if (sender is MenuItem mi && mi.DataContext is FamilyItem fam)
             {
-                FamilyBrowserCommand.ReloadFamilyHandlerInstance.FamilyPath = fam.Path;
+                var targets = GetEffectiveSelection(fam)
+                    .Select(f => f.Path)
+                    .Where(p => !string.IsNullOrWhiteSpace(p))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                FamilyBrowserCommand.ReloadFamilyHandlerInstance.FamilyPaths = targets;
+                FamilyBrowserCommand.ReloadFamilyHandlerInstance.FamilyPath = targets.FirstOrDefault();
                 FamilyBrowserCommand.ReloadFamilyEventInstance.Raise();
             }
         }
@@ -1316,12 +1328,136 @@ namespace Famille
 
         private void FamilyItem_DoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (e.ClickCount != 2) return;
-            if (sender is Border b && b.DataContext is FamilyItem fam)
+            if (sender is not Border b || b.DataContext is not FamilyItem fam)
+                return;
+
+            if (_isMultiSelectionEnabled)
             {
-                FamilyBrowserCommand.LoadFamilyHandlerInstance.FamilyPath = fam.Path;
-                FamilyBrowserCommand.LoadFamilyEventInstance.Raise();
+                if (e.ClickCount == 1)
+                {
+                    SelectFamilyFromClick(fam, Keyboard.Modifiers);
+                    e.Handled = true;
+                }
+                return;
             }
+
+            if (e.ClickCount != 2) return;
+            FamilyBrowserCommand.LoadFamilyHandlerInstance.FamilyPath = fam.Path;
+            FamilyBrowserCommand.LoadFamilyEventInstance.Raise();
+        }
+
+        private void FamilyItem_RightClickSelect(object sender, MouseButtonEventArgs e)
+        {
+            if (!_isMultiSelectionEnabled) return;
+            if (sender is not Border b || b.DataContext is not FamilyItem fam) return;
+
+            var selectedFamilies = GetSelectedFamilies();
+            if (!selectedFamilies.Contains(fam))
+            {
+                SelectFamilyFromClick(fam, ModifierKeys.None);
+            }
+        }
+
+        private void FamilyItem_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (sender is not Border border || border.ContextMenu == null)
+                return;
+
+            bool hasMultipleSelection = _isMultiSelectionEnabled && GetSelectedFamilies().Count > 1;
+            foreach (var item in border.ContextMenu.Items)
+            {
+                if (item is MenuItem menuItem)
+                {
+                    var header = menuItem.Header?.ToString();
+                    if (hasMultipleSelection)
+                    {
+                        bool keepVisible =
+                            string.Equals(header, "Ajouter à la collection active", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(header, "Charger la dernière version", StringComparison.OrdinalIgnoreCase);
+                        menuItem.Visibility = keepVisible ? Visibility.Visible : Visibility.Collapsed;
+                    }
+                    else
+                    {
+                        menuItem.Visibility = Visibility.Visible;
+                    }
+                }
+                else if (item is Separator separator)
+                {
+                    separator.Visibility = hasMultipleSelection ? Visibility.Collapsed : Visibility.Visible;
+                }
+            }
+        }
+
+        private void MultiSelectCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            _isMultiSelectionEnabled = MultiSelectCheckBox?.IsChecked == true;
+            if (!_isMultiSelectionEnabled)
+            {
+                ClearSelectedFamilies();
+                _lastSelectedFamily = null;
+            }
+        }
+
+        private void SelectFamilyFromClick(FamilyItem clickedFamily, ModifierKeys modifiers)
+        {
+            if (clickedFamily == null) return;
+
+            bool shift = (modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
+            bool ctrl = (modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+
+            if (shift && _lastSelectedFamily != null)
+            {
+                int start = displayedFamilies.IndexOf(_lastSelectedFamily);
+                int end = displayedFamilies.IndexOf(clickedFamily);
+                if (start >= 0 && end >= 0)
+                {
+                    if (!ctrl)
+                        ClearSelectedFamilies();
+
+                    int min = Math.Min(start, end);
+                    int max = Math.Max(start, end);
+                    for (int i = min; i <= max; i++)
+                        displayedFamilies[i].IsSelected = true;
+                }
+                else
+                {
+                    if (!ctrl)
+                        ClearSelectedFamilies();
+                    clickedFamily.IsSelected = true;
+                }
+            }
+            else if (ctrl)
+            {
+                clickedFamily.IsSelected = !clickedFamily.IsSelected;
+            }
+            else
+            {
+                ClearSelectedFamilies();
+                clickedFamily.IsSelected = true;
+            }
+
+            _lastSelectedFamily = clickedFamily;
+        }
+
+        private List<FamilyItem> GetSelectedFamilies()
+            => displayedFamilies.Where(f => f.IsSelected).ToList();
+
+        private List<FamilyItem> GetEffectiveSelection(FamilyItem contextFamily = null)
+        {
+            var selected = GetSelectedFamilies();
+            if (selected.Count > 0)
+                return selected;
+
+            if (contextFamily != null)
+                return new List<FamilyItem> { contextFamily };
+
+            return new List<FamilyItem>();
+        }
+
+        private void ClearSelectedFamilies()
+        {
+            foreach (var family in displayedFamilies.Where(f => f.IsSelected))
+                family.IsSelected = false;
         }
 
         private void OpenFamilyFile_Click(object sender, RoutedEventArgs e)
@@ -2620,19 +2756,36 @@ namespace Famille
         private void AddToActiveCollection_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuItem)?.DataContext is not FamilyItem fam) return;
+            AddFamiliesToActiveCollection(GetEffectiveSelection(fam));
+        }
+
+        private void AddFamiliesToActiveCollection(IEnumerable<FamilyItem> families)
+        {
+            var familyList = families?.Where(f => f != null).ToList() ?? new List<FamilyItem>();
+            if (familyList.Count == 0) return;
 
             if (_selectedCollection == null)
                 EnsureFavoritesCollection();
 
-            if (!_selectedCollection.Paths.Any(p => p.Equals(fam.Path, StringComparison.OrdinalIgnoreCase)))
+            bool updated = false;
+            foreach (var fam in familyList)
             {
+                if (_selectedCollection.Paths.Any(p => p.Equals(fam.Path, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
                 _selectedCollection.Paths.Add(fam.Path);
-                SaveCollections();
-                RefreshCollectionContent();
+                updated = true;
 
                 if (_selectedCollection.Id == FavoritesCollectionId)
-                {
                     fam.IsFavorite = true;
+            }
+
+            if (updated)
+            {
+                SaveCollections();
+                RefreshCollectionContent();
+                if (_selectedCollection.Id == FavoritesCollectionId)
+                {
                     ExportFavoritesCollectionToTxt();
                 }
             }
@@ -2849,6 +3002,13 @@ namespace Famille
         {
             get => _isFavorite;
             set { if (_isFavorite != value) { _isFavorite = value; OnPropertyChanged(nameof(IsFavorite)); } }
+        }
+
+        private bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set { if (_isSelected != value) { _isSelected = value; OnPropertyChanged(nameof(IsSelected)); } }
         }
 
         private string _revitSavedVersion;

--- a/BIMaestro/commands/Dossier famille/ReloadFamilyHandler.cs
+++ b/BIMaestro/commands/Dossier famille/ReloadFamilyHandler.cs
@@ -15,6 +15,7 @@ namespace Famille
     public class ReloadFamilyHandler : IExternalEventHandler
     {
         public string FamilyPath { get; set; }
+        public List<string> FamilyPaths { get; set; } = new List<string>();
 
         // Cache UX pour indiquer "déjà à jour" vs "nouvelle version"
         private static readonly Dictionary<string, DateTime> LastWriteTimes =
@@ -29,79 +30,105 @@ namespace Famille
                 UIDocument uidoc = uiapp.ActiveUIDocument;
                 Document doc = uidoc.Document;
 
-                if (string.IsNullOrWhiteSpace(FamilyPath) || !File.Exists(FamilyPath))
+                var targetPaths = (FamilyPaths ?? new List<string>())
+                    .Where(p => !string.IsNullOrWhiteSpace(p))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (targetPaths.Count == 0 && !string.IsNullOrWhiteSpace(FamilyPath))
+                    targetPaths.Add(FamilyPath);
+
+                targetPaths = targetPaths.Where(File.Exists).ToList();
+                if (targetPaths.Count == 0)
                 {
                     TaskDialog.Show("BIMaestro - Rechargement",
                         "Chemin de famille invalide ou fichier introuvable.");
                     return;
                 }
 
-                string famName = Path.GetFileNameWithoutExtension(FamilyPath);
+                bool singleMode = targetPaths.Count == 1;
+                int ok = 0;
+                int fail = 0;
+                string firstError = null;
 
-                // 1) UX : statut du fichier (n'empêche JAMAIS le rechargement)
-                DateTime currentWriteUtc = File.GetLastWriteTimeUtc(FamilyPath);
-                bool fileUnchanged = LastWriteTimes.TryGetValue(FamilyPath, out DateTime prevUtc)
-                                     && prevUtc == currentWriteUtc;
-
-                // 2) Recharger TOUJOURS en ECRASANT les valeurs de TYPE
-                Family reloaded = null;
-                using (var tx = new Transaction(doc, "Recharger famille (écraser valeurs de type)"))
+                foreach (var path in targetPaths)
                 {
-                    tx.Start();
-                    // >>> Nécessite la classe FamilyLoadOptionOverwrite (overwriteParameterValues = true)
-                    doc.LoadFamily(FamilyPath, new FamilyLoadOptionOverwrite(), out reloaded);
-                    tx.Commit();
-                }
-
-                // Met à jour le cache UX
-                LastWriteTimes[FamilyPath] = currentWriteUtc;
-
-                // Fallback si LoadFamily n'a rien retourné
-                if (reloaded == null)
-                {
-                    reloaded = new FilteredElementCollector(doc)
-                        .OfClass(typeof(Family))
-                        .Cast<Family>()
-                        .FirstOrDefault(f => f.Name.Equals(famName, StringComparison.OrdinalIgnoreCase));
-                    if (reloaded == null)
+                    try
                     {
-                        TaskDialog.Show("BIMaestro - Rechargement",
-                            $"Impossible de retrouver « {famName} » après rechargement.");
-                        return;
+                        string famName = Path.GetFileNameWithoutExtension(path);
+                        DateTime currentWriteUtc = File.GetLastWriteTimeUtc(path);
+                        bool fileUnchanged = LastWriteTimes.TryGetValue(path, out DateTime prevUtc)
+                                             && prevUtc == currentWriteUtc;
+
+                        Family reloaded = null;
+                        using (var tx = new Transaction(doc, "Recharger famille (écraser valeurs de type)"))
+                        {
+                            tx.Start();
+                            doc.LoadFamily(path, new FamilyLoadOptionOverwrite(), out reloaded);
+                            tx.Commit();
+                        }
+
+                        LastWriteTimes[path] = currentWriteUtc;
+
+                        if (reloaded == null)
+                        {
+                            reloaded = new FilteredElementCollector(doc)
+                                .OfClass(typeof(Family))
+                                .Cast<Family>()
+                                .FirstOrDefault(f => f.Name.Equals(famName, StringComparison.OrdinalIgnoreCase));
+                            if (reloaded == null)
+                                throw new InvalidOperationException($"Impossible de retrouver « {famName} » après rechargement.");
+                        }
+
+                        SafeRegenerate(doc);
+
+                        if (singleMode)
+                        {
+                            string suffix = fileUnchanged ? " (déjà à jour)." : " (nouvelle version détectée).";
+                            TaskDialog.Show("BIMaestro - Rechargement",
+                                $"La famille « {famName} » a été rechargée avec succès{suffix}");
+
+                            ElementId symId = reloaded.GetFamilySymbolIds().FirstOrDefault();
+                            if (symId != ElementId.InvalidElementId)
+                            {
+                                FamilySymbol symbol = doc.GetElement(symId) as FamilySymbol;
+                                if (symbol != null)
+                                {
+                                    if (!symbol.IsActive)
+                                    {
+                                        using (var tx2 = new Transaction(doc, "Activer type"))
+                                        {
+                                            tx2.Start();
+                                            symbol.Activate();
+                                            tx2.Commit();
+                                        }
+                                    }
+
+                                    uidoc.Selection.SetElementIds(new List<ElementId> { symbol.Id });
+                                    uidoc.PostRequestForElementTypePlacement(symbol);
+                                }
+                            }
+                        }
+
+                        FamilyUsageManager.RegisterUse(path);
+                        FamilyRecentManager.RegisterUse(path);
+                        ok++;
+                    }
+                    catch (Exception ex)
+                    {
+                        fail++;
+                        if (firstError == null)
+                            firstError = ex.Message;
                     }
                 }
 
-                // 3) Régénération SÉCURISÉE (évite l'InvalidOperationException)
-                SafeRegenerate(doc);
-
-                // 4) Message clair (toujours "rechargée")
-                string suffix = fileUnchanged ? " (déjà à jour)." : " (nouvelle version détectée).";
-                TaskDialog.Show("BIMaestro - Rechargement",
-                    $"La famille « {famName} » a été rechargée avec succès{suffix}");
-
-                // 5) Activer le premier type et proposer le placement
-                ElementId symId = reloaded.GetFamilySymbolIds().FirstOrDefault();
-                if (symId == ElementId.InvalidElementId) return;
-
-                FamilySymbol symbol = doc.GetElement(symId) as FamilySymbol;
-                if (symbol == null) return;
-
-                if (!symbol.IsActive)
+                if (!singleMode)
                 {
-                    using (var tx2 = new Transaction(doc, "Activer type"))
-                    {
-                        tx2.Start();
-                        symbol.Activate();
-                        tx2.Commit();
-                    }
+                    string message = $"Familles rechargées : {ok}\nÉchecs : {fail}";
+                    if (!string.IsNullOrWhiteSpace(firstError))
+                        message += $"\n\nPremier détail d'erreur : {firstError}";
+                    TaskDialog.Show("BIMaestro - Rechargement", message);
                 }
-
-                uidoc.Selection.SetElementIds(new List<ElementId> { symbol.Id });
-                uidoc.PostRequestForElementTypePlacement(symbol);
-
-                // Analytics facultatif
-                FamilyUsageManager.RegisterUse(FamilyPath);
-                FamilyRecentManager.RegisterUse(FamilyPath);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Allow selecting multiple families to perform batch operations such as reload and add-to-collection. 
- Improve visual feedback for selected items and make settings easier to navigate when content grows. 
- Extend the reload flow to process multiple family files in one operation and report aggregate results.

### Description
- XAML: added multi-select UI including a `MultiSelectCheckBox`, selection visual styling for `Border` (highlighted border, thicker stroke and background when selected), right-click selection (`PreviewMouseRightButtonDown`) and `ContextMenuOpening` handling, and wrapped the Settings panel in a `ScrollViewer` for vertical scrolling.  
- Selection behavior: implemented multi-selection state (`_isMultiSelectionEnabled`), last-click tracking (`_lastSelectedFamily`), methods `SelectFamilyFromClick`, `GetSelectedFamilies`, `GetEffectiveSelection`, and `ClearSelectedFamilies`, and wired mouse handlers (`FamilyItem_DoubleClick`, `FamilyItem_RightClickSelect`, `FamilyItem_ContextMenuOpening`, `MultiSelectCheckBox_Changed`).  
- Batch actions: `ReloadFamily_Click` now resolves the effective selection and passes a list of paths to the reload handler; `AddToActiveCollection_Click` was converted to `AddFamiliesToActiveCollection` to add multiple families and mark favorites appropriately; `BeginPaging` clears selection on new queries.  
- Reload handler: `ReloadFamilyHandler` now accepts `FamilyPaths` and processes multiple files with aggregated success/failure reporting while preserving single-file behavior (activation and placement prompt), and registers family usage for each reloaded file.  
- Model: added an `IsSelected` property to `FamilyItem` so UI bindings can reflect selection state.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e428f1c832e9e83273800864bb8)