### PR TITLE
Ajouter bouton « Modifier chemin » pour le dossier partagé dans Suivi maquette

### DIFF
--- a/BIMaestro/commands/Suivi maquette collaboratif/CollaborativeModelTrackerWindow.xaml
+++ b/BIMaestro/commands/Suivi maquette collaboratif/CollaborativeModelTrackerWindow.xaml
@@ -148,6 +148,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <TextBlock x:Name="InfoText"
@@ -157,12 +158,18 @@
                        TextWrapping="Wrap"
                        VerticalAlignment="Center"/>
 
-            <Button Grid.Column="1"
-                    Content="Ouvrir dossier"
-                    Width="150"
-                    Style="{StaticResource PrimaryButton}"
-                    HorizontalAlignment="Right"
-                    Click="OpenFolder_Click"/>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Modifier chemin"
+                        Width="160"
+                        Margin="0,0,10,0"
+                        Style="{StaticResource SecondaryButton}"
+                        Click="ChangeSharedPath_Click"/>
+
+                <Button Content="Ouvrir dossier"
+                        Width="150"
+                        Style="{StaticResource PrimaryButton}"
+                        Click="OpenFolder_Click"/>
+            </StackPanel>
         </Grid>
     </Grid>
 </Window>

--- a/BIMaestro/commands/Suivi maquette collaboratif/CollaborativeModelTrackerWindow.xaml.cs
+++ b/BIMaestro/commands/Suivi maquette collaboratif/CollaborativeModelTrackerWindow.xaml.cs
@@ -300,6 +300,50 @@ namespace Analyse
             Dispatcher.BeginInvoke(new Action(ApplyFilters), DispatcherPriority.Background);
         }
 
+
+        private void ChangeSharedPath_Click(object sender, RoutedEventArgs e)
+        {
+            var explanation =
+                "Pour un suivi collaboratif fiable, choisissez un dossier sur un serveur commun. " +
+                "Si le chemin reste local (PC perso), les autres utilisateurs ne pourront pas lire ou écrire les mêmes fichiers JSON/Excel.";
+
+            var userChoice = MessageBox.Show(
+                explanation + "\n\nVoulez-vous choisir ou modifier ce chemin maintenant ?",
+                "Chemin commun recommandé",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Information);
+
+            if (userChoice != MessageBoxResult.Yes)
+                return;
+
+            using (var dialog = new Forms.FolderBrowserDialog())
+            {
+                dialog.Description = "Sélectionnez le dossier commun (serveur) pour le suivi des maquettes";
+                dialog.SelectedPath = CollaborativeModelTrackerStore.ActiveDirectory;
+
+                if (dialog.ShowDialog() != Forms.DialogResult.OK || string.IsNullOrWhiteSpace(dialog.SelectedPath))
+                    return;
+
+                if (!CollaborativeModelTrackerStore.TrySetSharedDirectory(dialog.SelectedPath, out var error))
+                {
+                    MessageBox.Show($"Le chemin sélectionné n'est pas utilisable : {error}",
+                        "Chemin invalide",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return;
+                }
+
+                LoadRecords();
+                ApplyFilters();
+
+                MessageBox.Show(
+                    "Chemin commun mis à jour avec succès. Tous les utilisateurs pointant ce même dossier partageront les mêmes fichiers de suivi.",
+                    "Chemin mis à jour",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+        }
+
         private void OpenFolder_Click(object sender, RoutedEventArgs e)
         {
             OpenCurrentSelectedModelFolder();


### PR DESCRIPTION
### Motivation
- Permettre à l'utilisateur de définir ou modifier explicitement le dossier partagé utilisé pour stocker les fichiers de suivi afin que tous les utilisateurs pointent vers le même emplacement (serveur) et évitent des chemins locaux incompatibles.

### Description
- Ajout d'un nouveau bouton `Modifier chemin` dans `CollaborativeModelTrackerWindow.xaml` à côté du bouton `Ouvrir dossier` et ajustement de la grille pour l'accueillir.
- Ajout du handler `ChangeSharedPath_Click` dans `CollaborativeModelTrackerWindow.xaml.cs` qui affiche un message explicatif sur l'intérêt d'un serveur commun avant d'ouvrir un sélecteur de dossier.
- Le flux valide le dossier choisi via `CollaborativeModelTrackerStore.TrySetSharedDirectory`, recharge les enregistrements avec `LoadRecords()` et `ApplyFilters()` et affiche une confirmation en cas de succès.
- Les messages d'erreur sont affichés si le chemin sélectionné n'est pas utilisable.

### Testing
- Tentative de compilation avec `dotnet build 'BIMaestro/BIMaestro.csproj'` (automatisée) échouée pour des raisons d'environnement car `dotnet` n'est pas disponible (`dotnet: command not found`).
- Aucune autre suite de tests automatisés n'a été exécutée dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158930de5c832e93da39ef4c3906b9)